### PR TITLE
Trigger clip:selected event on resize completion

### DIFF
--- a/src/core/entities/player.ts
+++ b/src/core/entities/player.ts
@@ -560,7 +560,7 @@ export abstract class Player extends Entity {
 	}
 
 	private onPointerUp(): void {
-		if (this.isDragging) {
+		if (this.isDragging || this.scaleDirection !== null || this.isRotating) {
 			this.edit.setSelectedClip(this);
 		}
 


### PR DESCRIPTION
The clip selection behavior to trigger the `clip:selected` event not only when a clip is clicked, but also when a clip resize or rotation operation is completed. This ensures that applications can respond to all types of clip interactions through a single event handler.

# Changes

Updated the `onPointerUp` method in the Player class to trigger the `setSelectedClip` method when:

A clip is clicked (existing behavior)
A clip scaling operation is completed
A clip rotation operation is completed