### PR TITLE
fix: Update totalDuration after loading all clips in loadEdit()

### DIFF
--- a/src/core/entities/edit.ts
+++ b/src/core/entities/edit.ts
@@ -148,6 +148,8 @@ export class Edit extends Entity {
 				await this.addPlayer(trackIdx, clipPlayer);
 			}
 		}
+
+		this.updateTotalDuration();
 	}
 	public getEdit(): EditType {
 		const tracks: TrackType[] = [];


### PR DESCRIPTION
## Overview

This PR fixes incorrect totalDuration calculation after loading an edit via loadEdit().

## Reference

Fixes [#7](https://github.com/shotstack/shotstack-studio-sdk/issues/7).

## Changes
- Call updateTotalDuration() after all clips are loaded in loadEdit().

## Benefits
- Ensures totalDuration accurately reflects the full timeline after loading an edit.
- Prevents playback and rendering issues caused by incorrect duration values.