### PR TITLE
Fix changelog event name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Corrected totalDuration calculation issue in `loadEdit()` method. Explicitly cal
 
 - **Separated clip selection and state update events ([#6](https://github.com/shotstack/shotstack-studio-sdk/issues/6))**:
   - `clip:select` event now triggers only on initial selection (pointer down).
-  - Added new `clip:update` event triggered after state changes upon manipulation (pointer up), providing structured payload with previous and current clip states.
+  - Added new `clip:updated` event triggered after state changes upon manipulation (pointer up), providing structured payload with previous and current clip states.
 
 ## [1.1.1] - 2025-04-22
 


### PR DESCRIPTION
## Summary
- correct `clip:updated` event name in the 1.1.2 changelog entry

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683fd6d7e740832682b0ba31ba3d4aed