### PR TITLE
Feat/clean rich text schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
 		"vite-plugin-dts": "^4.5.4"
 	},
 	"dependencies": {
-		"@shotstack/shotstack-canvas": "^1.5.1",
+		"@shotstack/shotstack-canvas": "^1.5.3",
 		"fast-deep-equal": "^3.1.3",
 		"howler": "^2.2.4",
 		"mediabunny": "^1.11.2",

--- a/src/core/schemas/rich-text-asset.ts
+++ b/src/core/schemas/rich-text-asset.ts
@@ -101,20 +101,11 @@ const RichTextAnimationSchema = zod
 	})
 	.strict();
 
-const CustomFontSchema = zod
-	.object({
-		src: zod.string().url("Invalid font URL"),
-		family: zod.string(),
-		weight: zod.union([zod.string(), zod.number()]).default("400")
-	})
-	.strict();
 
 export const RichTextAssetSchema = zod
 	.object({
 		type: zod.literal("rich-text"),
 		text: zod.string().max(10000).default(""),
-		width: zod.number().min(1).max(8192).optional(),
-		height: zod.number().min(1).max(8192).optional(),
 		font: RichTextFontSchema.optional(),
 		style: RichTextStyleSchema.optional(),
 		stroke: RichTextStrokeSchema.optional(),
@@ -122,8 +113,7 @@ export const RichTextAssetSchema = zod
 		background: RichTextBackgroundSchema.optional(),
 		padding: RichTextPaddingSchema.optional(),
 		align: RichTextAlignmentSchema.optional(),
-		animation: RichTextAnimationSchema.optional(),
-		customFonts: zod.array(CustomFontSchema).optional()
+		animation: RichTextAnimationSchema.optional()
 	})
 	.strict();
 

--- a/src/templates/hello.json
+++ b/src/templates/hello.json
@@ -12,8 +12,6 @@
 						"asset": {
 							"type": "rich-text",
 							"text": "Hello World!",
-							"width": 800,
-							"height": 400,
 							"font": {
 								"family": "Roboto",
 								"size": 48,


### PR DESCRIPTION
Remove `width`, `height`, and `customFonts` from `RichTextAssetSchema`.

These are runtime concerns: dimensions come from clip config, custom fonts are resolved from `timeline.fonts` during render. The schema should validate user input, not internal engine payloads.

Adds `CanvasRichTextPayload` interface and `getResolvedDimensions()` to keep the runtime logic type-safe and DRY.