### PR TITLE
fix: remove incorrect division from clip length calculation in audio …

### DIFF
--- a/src/components/canvas/players/audio-player.ts
+++ b/src/components/canvas/players/audio-player.ts
@@ -167,7 +167,7 @@ export class AudioPlayer extends Player {
 			return volume ?? 1;
 		}
 
-		const clipLength = this.getLength() / 1000;
+		const clipLength = this.getLength();
 		const fade = Math.min(2, clipLength / 2);
 
 		if (effect === "fadeIn") {


### PR DESCRIPTION
Remove incorrect division from clip length calculation in audio player.

Fixes #90 