### PR TITLE
fix: upgrade @shotstack/schemas and @shotstack/shotstack-canvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,8 +99,8 @@
 		"vite-plugin-dts": "^4.5.4"
 	},
 	"dependencies": {
-		"@shotstack/schemas": "1.9.10",
-		"@shotstack/shotstack-canvas": "^2.1.12",
+		"@shotstack/schemas": "1.10.9",
+		"@shotstack/shotstack-canvas": "^2.4.3",
 		"howler": "^2.2.4",
 		"mediabunny": "^1.11.2",
 		"opentype.js": "^1.3.4",


### PR DESCRIPTION
Bumps both upstream packages to current versions.

@shotstack/schemas 1.9.10 → 1.10.9
- New optional wrap field on rich-text, rich-caption, and TextBackground.
- Relaxed src validation for rich-caption.

@shotstack/shotstack-canvas ^2.1.12 → ^2.4.3
- wrap rendering implementation.
- HarfBuzz WASM segfault fix on repeated FontRegistry create/destroy.
- Various rich-caption fixes.