### PR TITLE
fix: clamp clip resize height to schema max (2160)

### DIFF
--- a/src/core/interaction/clip-interaction.ts
+++ b/src/core/interaction/clip-interaction.ts
@@ -15,8 +15,10 @@ import type { Size, Vector } from "@layouts/geometry";
 export const INTERACTION_CONSTANTS = {
 	/** Minimum clip dimension in pixels */
 	MIN_DIMENSION: 50,
-	/** Maximum clip dimension in pixels */
-	MAX_DIMENSION: 3840
+	/** Maximum clip width in pixels */
+	MAX_WIDTH: 3840,
+	/** Maximum clip height in pixels */
+	MAX_HEIGHT: 2160
 } as const;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -222,8 +224,8 @@ export function calculateEdgeResize(direction: EdgeDirection, delta: Vector, ori
  */
 export function clampDimensions(width: number, height: number): { width: number; height: number } {
 	return {
-		width: Math.max(INTERACTION_CONSTANTS.MIN_DIMENSION, Math.min(width, INTERACTION_CONSTANTS.MAX_DIMENSION)),
-		height: Math.max(INTERACTION_CONSTANTS.MIN_DIMENSION, Math.min(height, INTERACTION_CONSTANTS.MAX_DIMENSION))
+		width: Math.max(INTERACTION_CONSTANTS.MIN_DIMENSION, Math.min(width, INTERACTION_CONSTANTS.MAX_WIDTH)),
+		height: Math.max(INTERACTION_CONSTANTS.MIN_DIMENSION, Math.min(height, INTERACTION_CONSTANTS.MAX_HEIGHT))
 	};
 }
 

--- a/tests/clip-interaction.test.ts
+++ b/tests/clip-interaction.test.ts
@@ -24,8 +24,9 @@ describe("ClipInteractionSystem", () => {
 			expect(INTERACTION_CONSTANTS.MIN_DIMENSION).toBe(50);
 		});
 
-		it("has correct maximum dimension", () => {
-			expect(INTERACTION_CONSTANTS.MAX_DIMENSION).toBe(3840);
+		it("has correct maximum dimensions", () => {
+			expect(INTERACTION_CONSTANTS.MAX_WIDTH).toBe(3840);
+			expect(INTERACTION_CONSTANTS.MAX_HEIGHT).toBe(2160);
 		});
 	});
 
@@ -425,7 +426,7 @@ describe("ClipInteractionSystem", () => {
 		it("clamps width above maximum", () => {
 			const result = clampDimensions(5000, 100);
 
-			expect(result.width).toBe(INTERACTION_CONSTANTS.MAX_DIMENSION);
+			expect(result.width).toBe(INTERACTION_CONSTANTS.MAX_WIDTH);
 			expect(result.height).toBe(100);
 		});
 
@@ -433,7 +434,7 @@ describe("ClipInteractionSystem", () => {
 			const result = clampDimensions(100, 5000);
 
 			expect(result.width).toBe(100);
-			expect(result.height).toBe(INTERACTION_CONSTANTS.MAX_DIMENSION);
+			expect(result.height).toBe(INTERACTION_CONSTANTS.MAX_HEIGHT);
 		});
 
 		it("preserves valid dimensions", () => {
@@ -447,7 +448,7 @@ describe("ClipInteractionSystem", () => {
 			const result = clampDimensions(30, 5000);
 
 			expect(result.width).toBe(INTERACTION_CONSTANTS.MIN_DIMENSION);
-			expect(result.height).toBe(INTERACTION_CONSTANTS.MAX_DIMENSION);
+			expect(result.height).toBe(INTERACTION_CONSTANTS.MAX_HEIGHT);
 		});
 
 		it("handles boundary values", () => {
@@ -455,9 +456,9 @@ describe("ClipInteractionSystem", () => {
 			expect(minResult.width).toBe(50);
 			expect(minResult.height).toBe(50);
 
-			const maxResult = clampDimensions(3840, 3840);
+			const maxResult = clampDimensions(3840, 2160);
 			expect(maxResult.width).toBe(3840);
-			expect(maxResult.height).toBe(3840);
+			expect(maxResult.height).toBe(2160);
 		});
 	});
 


### PR DESCRIPTION
## Summary
- `clampDimensions()` capped both axes at 3840, but `ResolvedClipSchema` requires `height ≤ 2160`. Any clip resize that crossed 2160 px height threw an unhandled `ZodError` inside the pixi `pointerup` listener.
- Split `MAX_DIMENSION` into `MAX_WIDTH` (3840) and `MAX_HEIGHT` (2160) so the interaction clamp stops at the same bound the schema enforces.

## Root cause
- `src/core/interaction/clip-interaction.ts` — symmetric `MAX_DIMENSION: 3840` clamp.
- `src/core/ui/selection-handles.ts:567` — pointer-up calls `edit.commitClipUpdate(...)`.
- `src/core/edit-session.ts:1062` — `ResolvedClipSchema.parse(finalConfig)` throws synchronously.
- `@shotstack/schemas/zod` — `width: z.number().lte(3840)`, `height: z.number().lte(2160)`.

## Sentry
Top issue by volume on dashboard-v2: [DASHBOARD-V2-29](https://shotstack.sentry.io/issues/DASHBOARD-V2-29) — 1,690 captured events / 14 days at 5% sample rate (~34k actual occurrences).

## Test plan
- [x] `npx jest tests/clip-interaction.test.ts` — 56 / 56 pass (assertions updated to use the new constants; the 3840×3840 boundary case now expects the legal 3840×2160 maximum).
- [x] `npm run typecheck` — clean.
- [x] Full suite via pre-push hook — 1775 / 1775 pass.
- [x] Manual: drag the bottom edge of a clip past 2160 px on a vertical (9:16) canvas — handle should stop at 2160 instead of throwing.

## Out of scope (deliberate, YAGNI)
- No `safeParse` migration in `edit-session.ts` — once the clamp matches the schema, the throw path is unreachable.
- No new public event (`ClipUpdateRejected`) — nothing subscribes to it.
- No upstream OpenAPI/spec change — the 2160 asymmetry is a separate API discussion; dashboards render fine inside the existing 4K bound.
- No package version bump — release flow handles that.