### PR TITLE
chore(deps): require @shotstack/shotstack-canvas ^2.8.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
 	},
 	"dependencies": {
 		"@shotstack/schemas": "1.11.0",
-		"@shotstack/shotstack-canvas": "^2.8.0",
+		"@shotstack/shotstack-canvas": "^2.8.3",
 		"howler": "^2.2.4",
 		"mediabunny": "^1.11.2",
 		"opentype.js": "^1.3.4",


### PR DESCRIPTION
Raises the `@shotstack/shotstack-canvas` floor from `^2.8.0` to `^2.8.3`.