### PR TITLE
fix: resolve font family names with surrounding whitespace to the declared font

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
 	},
 	"dependencies": {
 		"@shotstack/schemas": "1.11.0",
-		"@shotstack/shotstack-canvas": "^2.8.3",
+		"@shotstack/shotstack-canvas": "^2.9.0",
 		"howler": "^2.2.4",
 		"mediabunny": "^1.11.2",
 		"opentype.js": "^1.3.4",

--- a/src/core/fonts/font-config.ts
+++ b/src/core/fonts/font-config.ts
@@ -2,11 +2,13 @@
  * Shared font configuration for text and rich-text players
  */
 
+import { parseFontFamily as parseCanvasFontFamily } from "@shotstack/shotstack-canvas";
+
 import { GOOGLE_FONTS_BY_FILENAME, GOOGLE_FONTS_BY_NAME } from "./google-fonts";
 
 const FONT_CDN = "https://templates.shotstack.io/basic/asset/font";
 
-/** Font family name to file path mapping (variable fonts where available, matching Edit API) */
+/** Font family name to its CDN file path (variable fonts where available). */
 export const FONT_PATHS: Record<string, string> = {
 	Arapey: `${FONT_CDN}/arapey-regular.ttf`,
 	"Clear Sans": `${FONT_CDN}/clearsans-regular.ttf`,
@@ -31,7 +33,7 @@ export const FONT_ALIASES: Record<string, string> = {
 	WorkSans: "Work Sans"
 };
 
-/** Weight modifier suffixes mapped to CSS font-weight values */
+/** Font weight modifier names mapped to their CSS numeric weight (e.g. "ExtraBold" → 800). */
 export const WEIGHT_MODIFIERS: Record<string, number> = {
 	Thin: 100,
 	ExtraLight: 200,
@@ -45,22 +47,13 @@ export const WEIGHT_MODIFIERS: Record<string, number> = {
 };
 
 /**
- * Parse a font family name to extract base family and weight
- * e.g., "Montserrat ExtraBold" → { baseFontFamily: "Montserrat", fontWeight: 800 }
- * Case-insensitive matching for weight modifiers (handles "Extrabold", "ExtraBold", etc.)
+ * Parse a font family name into its base family and CSS weight.
+ * e.g. "Montserrat ExtraBold" → { baseFontFamily: "Montserrat", fontWeight: 800 }.
+ * Surrounding whitespace is trimmed, so "Montserrat ExtraBold " parses to the same result.
  */
 export function parseFontFamily(fontFamily: string): { baseFontFamily: string; fontWeight: number } {
-	const lowerFamily = fontFamily.toLowerCase();
-	for (const [modifier, weight] of Object.entries(WEIGHT_MODIFIERS)) {
-		const lowerModifier = ` ${modifier.toLowerCase()}`;
-		if (lowerFamily.endsWith(lowerModifier)) {
-			return {
-				baseFontFamily: fontFamily.slice(0, -modifier.length - 1),
-				fontWeight: weight
-			};
-		}
-	}
-	return { baseFontFamily: fontFamily, fontWeight: 400 };
+	const { family, weight } = parseCanvasFontFamily(fontFamily);
+	return { baseFontFamily: family, fontWeight: Number(weight) };
 }
 
 /**


### PR DESCRIPTION
Studio's `parseFontFamily` now delegates to the shared `@shotstack/shotstack-canvas` parser (bumped to `^2.9.0`), so a family name is split consistently wherever it is used.

**Behaviour change:** a `font.family` with leading/trailing whitespace — common from CMS fields and `{{merge}}` variables — now resolves to the declared font instead of a fallback. Every diverging input moves toward the declared intent; none regresses.

## Changes
- Bump `@shotstack/shotstack-canvas` → `^2.9.0`.
- `font-config.ts`: `parseFontFamily` delegates to the shared parser; keeps the `{baseFontFamily, fontWeight}` return shape so call sites are untouched.

## Validation
26-input old-vs-new equivalence (clean inputs identical; whitespace/null inputs now resolve instead of falling through); `tsc --noEmit` clean; 1791 tests pass. `parseFontFamily` is not part of the public API.