### PR TITLE
fix(deps): bump @shotstack/schemas to 1.13.0; handle optional asset src

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
 		"vite-plugin-dts": "^4.5.4"
 	},
 	"dependencies": {
-		"@shotstack/schemas": "1.11.0",
+		"@shotstack/schemas": "1.13.0",
 		"@shotstack/shotstack-canvas": "^2.9.0",
 		"howler": "^2.2.4",
 		"mediabunny": "^1.11.2",

--- a/src/components/canvas/players/audio-player.ts
+++ b/src/components/canvas/players/audio-player.ts
@@ -30,6 +30,7 @@ export class AudioPlayer extends Player {
 		const audioClipConfiguration = this.clipConfiguration.asset as AudioAsset;
 
 		const identifier = audioClipConfiguration.src;
+		if (!identifier) return;
 		const loadOptions: pixi.UnresolvedAsset = { src: identifier, parser: AudioLoadParser.Name };
 		const audioResource = await this.edit.assetLoader.load<howler.Howl>(identifier, loadOptions);
 
@@ -123,8 +124,10 @@ export class AudioPlayer extends Player {
 		this.syncTimer = 0;
 
 		const audioAsset = this.clipConfiguration.asset as AudioAsset;
-		const loadOptions: pixi.UnresolvedAsset = { src: audioAsset.src, parser: AudioLoadParser.Name };
-		const audioResource = await this.edit.assetLoader.load<howler.Howl>(audioAsset.src, loadOptions);
+		const { src } = audioAsset;
+		if (!src) return;
+		const loadOptions: pixi.UnresolvedAsset = { src, parser: AudioLoadParser.Name };
+		const audioResource = await this.edit.assetLoader.load<howler.Howl>(src, loadOptions);
 
 		if (!(audioResource instanceof howler.Howl)) {
 			throw new Error(`Invalid audio source '${audioAsset.src}'.`);

--- a/src/components/canvas/players/image-player.ts
+++ b/src/components/canvas/players/image-player.ts
@@ -86,6 +86,7 @@ export class ImagePlayer extends Player {
 	private async loadTexture(): Promise<void> {
 		const imageAsset = this.clipConfiguration.asset as ImageAsset;
 		const { src } = imageAsset;
+		if (!src) return;
 
 		const corsUrl = `${src}${src.includes("?") ? "&" : "?"}x-cors=1`;
 		const loadOptions: pixi.UnresolvedAsset = { src: corsUrl, crossorigin: "anonymous", data: {} };

--- a/src/components/canvas/players/video-player.ts
+++ b/src/components/canvas/players/video-player.ts
@@ -168,6 +168,7 @@ export class VideoPlayer extends Player {
 	private async loadVideo(): Promise<void> {
 		const videoAsset = this.clipConfiguration.asset as VideoAsset;
 		const { src } = videoAsset;
+		if (!src) return;
 
 		if (src.endsWith(".mov")) {
 			throw new Error(`Video source '${src}' is not supported. .mov files cannot be played in the browser. Please convert to .webm or .mp4 first.`);

--- a/src/components/timeline/media-thumbnail-renderer.ts
+++ b/src/components/timeline/media-thumbnail-renderer.ts
@@ -126,6 +126,13 @@ export class MediaThumbnailRenderer implements ClipRenderer {
 		const state: ThumbnailState = { loading: true, thumbnails: [], thumbnailWidth: 0, failed: false };
 		this.clipStates.set(clipKey, state);
 
+		if (!asset.src) {
+			state.loading = false;
+			state.failed = true;
+			this.onRendered();
+			return;
+		}
+
 		try {
 			const result = await this.generator.generateThumbnail(asset.src, asset.trim ?? 0);
 
@@ -154,6 +161,13 @@ export class MediaThumbnailRenderer implements ClipRenderer {
 	private async generateAndApplyImage(element: HTMLElement, asset: ImageAsset, clipKey: string): Promise<void> {
 		const state: ThumbnailState = { loading: true, thumbnails: [], thumbnailWidth: 0, failed: false };
 		this.clipStates.set(clipKey, state);
+
+		if (!asset.src) {
+			state.loading = false;
+			state.failed = true;
+			this.onRendered();
+			return;
+		}
 
 		try {
 			const result = await this.loadImageThumbnail(asset.src);


### PR DESCRIPTION
## What

Bumps `@shotstack/schemas` 1.11.0 → 1.13.0 and adapts the SDK to its `src`-or-`prompt` change. (`@shotstack/shotstack-canvas` is already at the latest, 2.9.0.)

## Why

1.13.0 makes `asset.src` optional — media assets can now be defined by a `prompt` (AI generation) instead of a `src`. That turns `asset.src` into `string | undefined`, which broke 7 sites that assumed it was always present.

## Changes

- `audio-player`, `image-player`, `video-player`: skip loading when an asset has no `src` (nothing to load until it's generated).
- `media-thumbnail-renderer`: mark the thumbnail failed and skip when there's no `src`.

## Testing

`npm run verify:ci` passes — lint, typecheck, jest, build, and the package contract (bundle `umd 2.92 MB`, under the 3.0 MB limit).

Supersedes the Dependabot bump in #121, which failed CI on exactly these type errors.
