### PR TITLE
fix: throw a clear error when a media asset has no src

### DIFF
--- a/src/components/canvas/players/audio-player.ts
+++ b/src/components/canvas/players/audio-player.ts
@@ -30,6 +30,9 @@ export class AudioPlayer extends Player {
 		const audioClipConfiguration = this.clipConfiguration.asset as AudioAsset;
 
 		const identifier = audioClipConfiguration.src;
+		if (!identifier) {
+			throw new Error("Audio asset is missing a 'src'.");
+		}
 		const loadOptions: pixi.UnresolvedAsset = { src: identifier, parser: AudioLoadParser.Name };
 		const audioResource = await this.edit.assetLoader.load<howler.Howl>(identifier, loadOptions);
 
@@ -123,6 +126,9 @@ export class AudioPlayer extends Player {
 		this.syncTimer = 0;
 
 		const audioAsset = this.clipConfiguration.asset as AudioAsset;
+		if (!audioAsset.src) {
+			throw new Error("Audio asset is missing a 'src'.");
+		}
 		const loadOptions: pixi.UnresolvedAsset = { src: audioAsset.src, parser: AudioLoadParser.Name };
 		const audioResource = await this.edit.assetLoader.load<howler.Howl>(audioAsset.src, loadOptions);
 

--- a/src/components/canvas/players/image-player.ts
+++ b/src/components/canvas/players/image-player.ts
@@ -86,6 +86,9 @@ export class ImagePlayer extends Player {
 	private async loadTexture(): Promise<void> {
 		const imageAsset = this.clipConfiguration.asset as ImageAsset;
 		const { src } = imageAsset;
+		if (!src) {
+			throw new Error("Image asset is missing a 'src'.");
+		}
 
 		const corsUrl = `${src}${src.includes("?") ? "&" : "?"}x-cors=1`;
 		const loadOptions: pixi.UnresolvedAsset = { src: corsUrl, crossorigin: "anonymous", data: {} };

--- a/src/components/canvas/players/video-player.ts
+++ b/src/components/canvas/players/video-player.ts
@@ -168,6 +168,9 @@ export class VideoPlayer extends Player {
 	private async loadVideo(): Promise<void> {
 		const videoAsset = this.clipConfiguration.asset as VideoAsset;
 		const { src } = videoAsset;
+		if (!src) {
+			throw new Error("Video asset is missing a 'src'.");
+		}
 
 		if (src.endsWith(".mov")) {
 			throw new Error(`Video source '${src}' is not supported. .mov files cannot be played in the browser. Please convert to .webm or .mp4 first.`);

--- a/src/components/timeline/media-thumbnail-renderer.ts
+++ b/src/components/timeline/media-thumbnail-renderer.ts
@@ -127,7 +127,11 @@ export class MediaThumbnailRenderer implements ClipRenderer {
 		this.clipStates.set(clipKey, state);
 
 		try {
-			const result = await this.generator.generateThumbnail(asset.src, asset.trim ?? 0);
+			const { src } = asset;
+			if (!src) {
+				throw new Error("Video asset is missing a 'src'.");
+			}
+			const result = await this.generator.generateThumbnail(src, asset.trim ?? 0);
 
 			// Check if element is still in DOM (might have been disposed)
 			if (!element.isConnected) return;
@@ -156,7 +160,11 @@ export class MediaThumbnailRenderer implements ClipRenderer {
 		this.clipStates.set(clipKey, state);
 
 		try {
-			const result = await this.loadImageThumbnail(asset.src);
+			const { src } = asset;
+			if (!src) {
+				throw new Error("Image asset is missing a 'src'.");
+			}
+			const result = await this.loadImageThumbnail(src);
 
 			// Check if element is still in DOM (might have been disposed)
 			if (!element.isConnected) return;


### PR DESCRIPTION
## What
Restore a clean `tsc` on `main`. The audio/image/video players and the timeline thumbnail renderer read `asset.src` directly, but the generated `@shotstack/schemas` types mark `src` as optional — so each use was a `string | undefined` type error (7 in total). A red type-check gate also masks any genuinely new errors.

## How
Guard `src` at each point of use and throw an explicit `… asset is missing a 'src'` error — consistent with the existing invalid-source handling — which also narrows the type to `string`. No changes to generated schema types, no `!`/`as` assertions.

## Behaviour
A media clip whose asset has no `src` now fails with a clear error instead of building an `undefined…` URL and failing obscurely. A thumbnail for such a clip falls back to the existing solid-colour state.

## Verify
- `tsc --noEmit` and `tsc --project tsconfig.test.json --noEmit` both clean (pushed with the pre-push gate enabled, no bypass).
- Full unit suite green (1802).
