### PR TITLE
fix: resolve existing placeholders when merge fields are registered after load

### DIFF
--- a/src/core/edit-session.ts
+++ b/src/core/edit-session.ts
@@ -2297,6 +2297,24 @@ export class Edit {
 		return this.mergeFieldService.resolve(input);
 	}
 
+	/**
+	 * Re-detect merge field placeholders across the document and re-resolve the canvas.
+	 * Use after registering or updating fields directly on the merge field service (rather
+	 * than through a clip-level command): clips that already contain `{{ FIELD }}`
+	 * placeholders pick up their resolved values immediately, without a reload.
+	 */
+	public refreshMergeFields(): void {
+		const bindingsPerClip = this.detectMergeFieldBindings(this.mergeFieldService.toSerializedArray());
+		for (const [clipId, bindings] of bindingsPerClip) {
+			if (bindings.size > 0) {
+				this.document.setClipBindingsForClip(clipId, bindings);
+			}
+		}
+		// resolve() recomputes the resolved edit and emits Resolved — the player
+		// reconciler and timeline react to that event and repaint with the new values.
+		this.resolve();
+	}
+
 	// ─── Template Edit Access (via document bindings) ──────────────────────────
 
 	/* @internal Get the exportable clip (with merge field placeholders restored) */

--- a/tests/edit-load.test.ts
+++ b/tests/edit-load.test.ts
@@ -748,6 +748,31 @@ describe("Edit loadEdit()", () => {
 			const player = edit.getPlayerClip(0, 0);
 			expect(player?.clipConfiguration.asset).toHaveProperty("src", "https://example.com/img.jpg");
 		});
+
+		it("refreshMergeFields resolves placeholders registered after load", async () => {
+			const shotstackEdit = new ShotstackEdit({
+				timeline: {
+					tracks: [{ clips: [{ asset: { type: "image", src: "{{ MEDIA_URL }}" }, start: 0, length: 3, fit: "crop" }] }]
+				},
+				output: { size: { width: 1920, height: 1080 }, format: "mp4" }
+			});
+			await shotstackEdit.load();
+
+			// No merge array at load → the placeholder stays literal in the resolved edit.
+			const before = shotstackEdit.getEdit({ includeIds: true });
+			const clipId = (before.timeline?.tracks?.[0]?.clips?.[0] as { id?: string })?.id as string;
+			expect(shotstackEdit.getResolvedClipById(clipId)?.asset).toHaveProperty("src", "{{ MEDIA_URL }}");
+
+			shotstackEdit.mergeFields.register({ name: "MEDIA_URL", defaultValue: "https://resolved.example.com/img.jpg" });
+			shotstackEdit.refreshMergeFields();
+
+			// Resolved side picks up the default; the document keeps the placeholder and the field.
+			expect(shotstackEdit.getResolvedClipById(clipId)?.asset).toHaveProperty("src", "https://resolved.example.com/img.jpg");
+			const after = shotstackEdit.getEdit();
+			const documentAsset = after.timeline?.tracks?.[0]?.clips?.[0]?.asset as { src?: string } | undefined;
+			expect(documentAsset?.src).toBe("{{ MEDIA_URL }}");
+			expect(after.merge).toEqual([{ find: "MEDIA_URL", replace: "https://resolved.example.com/img.jpg" }]);
+		});
 	});
 
 	describe("fonts", () => {


### PR DESCRIPTION
Registering a merge field directly on the service (mergeFields.register) updates the registry but nothing re-resolves clips that already contain the placeholder — the canvas keeps showing literal {{ braces }} until the clip re-renders for an unrelated reason (e.g. selecting it routes through the toolbar's resolve path).

Adds Edit.refreshMergeFields(): re-runs load-time placeholder detection over the document, updates clip bindings, and resolves — the Resolved event drives the player reconciler and timeline repaint, the same mechanism SetMergeFieldCommand relies on. The document keeps placeholders; only the resolved view and bindings change.

Verified with a regression test (placeholder literal after load with no merge array; registered + refreshed → resolved on the resolved clip, document still holds the placeholder and serialises the merge entry). Full suite: 1814 tests pass, typecheck and lint clean.