### PR TITLE
feat: surface command outcomes (success/noop) from Edit mutators

### DIFF
--- a/src/core/edit-session.ts
+++ b/src/core/edit-session.ts
@@ -942,6 +942,12 @@ export class Edit {
 			const lumaIndex = track.findIndex(clip => clip.playerType === PlayerType.Luma);
 
 			if (lumaIndex !== -1) {
+				// Refuse atomically up front: once the luma is gone the content deletion below
+				// would hit the last-clip rule, and a refusal must not half-apply by deleting the luma
+				if (this.document.getClipCount() <= 2) {
+					return CommandNoop("Cannot delete the last clip");
+				}
+
 				// Delete luma first (handles index shifting correctly)
 				// If luma comes before content clip, content clip index shifts after luma deletion
 				const adjustedContentIdx = lumaIndex < clipIdx ? clipIdx - 1 : clipIdx;

--- a/src/core/edit-session.ts
+++ b/src/core/edit-session.ts
@@ -55,7 +55,7 @@ import { calculateOverlap } from "@timeline/interaction/interaction-calculations
 import * as pixi from "pixi.js";
 
 import { CommandQueue } from "./commands/command-queue";
-import type { EditCommand, CommandContext, CommandResult } from "./commands/types";
+import { CommandNoop, type EditCommand, type CommandContext, type CommandResult } from "./commands/types";
 import { EditDocument } from "./edit-document";
 import { PlayerReconciler } from "./player-reconciler";
 import { resolve as resolveDocument, resolveClip as resolveClipById, type SingleClipContext } from "./resolver";
@@ -419,36 +419,46 @@ export class Edit {
 
 	/**
 	 * Patch fields on a clip identified by stable ID.
+	 *
+	 * Resolves with the command outcome: `success` when the clip was updated, or `noop`
+	 * (with a `message`) when no clip matches `clipId`.
 	 */
-	public updateClipById(clipId: string, updates: Partial<Clip>): Promise<void> {
+	public updateClipById(clipId: string, updates: Partial<Clip>): Promise<CommandResult> {
 		const found = this.document.getClipById(clipId);
 		if (!found) {
 			console.warn(`updateClipById: no clip with id ${clipId}`);
-			return Promise.resolve();
+			return Promise.resolve(CommandNoop(`No clip with id ${clipId}`));
 		}
 		return this.updateClip(found.trackIndex, found.clipIndex, updates);
 	}
 
 	/**
 	 * Remove a clip identified by stable ID.
+	 *
+	 * Resolves with the command outcome: `success` when the clip was removed, or `noop`
+	 * (with a `message`) when no clip matches `clipId` or the deletion was refused —
+	 * the timeline always keeps at least one clip.
 	 */
-	public deleteClipById(clipId: string): Promise<void> {
+	public deleteClipById(clipId: string): Promise<CommandResult> {
 		const found = this.document.getClipById(clipId);
 		if (!found) {
 			console.warn(`deleteClipById: no clip with id ${clipId}`);
-			return Promise.resolve();
+			return Promise.resolve(CommandNoop(`No clip with id ${clipId}`));
 		}
 		return this.deleteClip(found.trackIndex, found.clipIndex);
 	}
 
 	/**
 	 * Move a clip identified by stable ID to a different track and/or start time.
+	 *
+	 * Resolves with the command outcome: `success` when the clip was moved, or `noop`
+	 * (with a `message`) when no clip matches `clipId`.
 	 */
-	public moveClipById(clipId: string, toTrackIndex: number, newStart?: Seconds): Promise<void> {
+	public moveClipById(clipId: string, toTrackIndex: number, newStart?: Seconds): Promise<CommandResult> {
 		const found = this.document.getClipById(clipId);
 		if (!found) {
 			console.warn(`moveClipById: no clip with id ${clipId}`);
-			return Promise.resolve();
+			return Promise.resolve(CommandNoop(`No clip with id ${clipId}`));
 		}
 		const currentStart = found.clip.start;
 		const start = newStart ?? (typeof currentStart === "number" ? (currentStart as Seconds) : null);
@@ -460,7 +470,7 @@ export class Edit {
 			);
 		}
 		const command = new MoveClipCommand(found.trackIndex, found.clipIndex, toTrackIndex, start);
-		return Promise.resolve(this.executeCommand(command));
+		return this.executeCommand(command);
 	}
 
 	/**
@@ -614,7 +624,7 @@ export class Edit {
 		return updated !== false;
 	}
 
-	public async addClip(trackIdx: number, clip: Clip): Promise<void> {
+	public async addClip(trackIdx: number, clip: Clip): Promise<CommandResult> {
 		ClipSchema.parse(clip);
 		await this.preflightAssetUrls(extractClipUrls(clip));
 		// Cast to ResolvedClip - the Player and timing resolver handle "auto"/"end" at runtime
@@ -909,13 +919,20 @@ export class Edit {
 		return this.document.getClip(trackIdx, clipIdx) !== null;
 	}
 
-	public async deleteClip(trackIdx: number, clipIdx: number): Promise<void> {
+	/**
+	 * Delete the clip at `(trackIdx, clipIdx)`, along with any luma matte attached to it.
+	 *
+	 * Resolves with the command outcome for the requested clip: `success` when it was
+	 * removed, or `noop` (with a `message`) when there is no clip at that position or the
+	 * deletion was refused — the timeline always keeps at least one clip.
+	 */
+	public async deleteClip(trackIdx: number, clipIdx: number): Promise<CommandResult> {
 		const track = this.tracks[trackIdx];
-		if (!track) return;
+		if (!track) return CommandNoop(`No track at index ${trackIdx}`);
 
 		// Get the clip being deleted
 		const clipToDelete = track[clipIdx];
-		if (!clipToDelete) return;
+		if (!clipToDelete) return CommandNoop(`No clip at track ${trackIdx}, index ${clipIdx}`);
 
 		// Check if this is a content clip (not a luma)
 		const isContentClip = clipToDelete.playerType !== PlayerType.Luma;
@@ -932,27 +949,29 @@ export class Edit {
 				const lumaCommand = new DeleteClipCommand(trackIdx, lumaIndex);
 				await this.executeCommand(lumaCommand);
 
-				// Now delete content clip with adjusted index
+				// Now delete content clip with adjusted index — this outcome is the one the
+				// caller asked about, so it is the one returned
 				const contentCommand = new DeleteClipCommand(trackIdx, adjustedContentIdx);
-				await this.executeCommand(contentCommand);
-				return;
+				return this.executeCommand(contentCommand);
 			}
 		}
 
 		// No luma attachment or deleting a luma directly - just delete the clip
 		const command = new DeleteClipCommand(trackIdx, clipIdx);
-		await this.executeCommand(command);
+		return this.executeCommand(command);
 	}
 
-	public async addTrack(trackIdx: number, track: Track): Promise<void> {
+	public async addTrack(trackIdx: number, track: Track): Promise<CommandResult> {
 		TrackSchema.parse(track);
 		await this.preflightAssetUrls(extractTrackUrls(track));
 
 		// Single atomic command — track + all its clips in one undo step.
-		await this.executeCommand(new AddTrackCommand(trackIdx, track));
+		const result = await this.executeCommand(new AddTrackCommand(trackIdx, track));
 
 		// Auto-link caption clips with unresolved alias sources
 		await this.autoLinkCaptionSources(trackIdx, track.clips);
+
+		return result;
 	}
 
 	/**
@@ -1006,43 +1025,62 @@ export class Edit {
 		};
 	}
 
-	public deleteTrack(trackIdx: number): void {
+	/**
+	 * Delete the track at `trackIdx` and all of its clips.
+	 *
+	 * Resolves with the command outcome: `success` when the track was removed, or `noop`
+	 * (with a `message`) when the deletion was refused — the timeline always keeps at
+	 * least one track.
+	 */
+	public deleteTrack(trackIdx: number): Promise<CommandResult> {
 		const command = new DeleteTrackCommand(trackIdx);
-		this.executeCommand(command);
+		return this.executeCommand(command);
 	}
 
-	public undo(): Promise<void> {
+	/**
+	 * Undo the most recent command.
+	 *
+	 * Resolves with the outcome: `success` when a command was undone, or `noop` (with a
+	 * `message`) when the history is empty or the command cannot be undone.
+	 */
+	public undo(): Promise<CommandResult> {
 		return this.commandQueue.enqueue(async () => {
-			if (this.commandIndex >= 0) {
-				const command = this.commandHistory[this.commandIndex];
-				if (command.undo) {
-					const context = this.createCommandContext();
-					// Always await - harmless on sync results, works across realms
-					await Promise.resolve(command.undo(context));
-					// Only decrement after successful completion
-					this.commandIndex -= 1;
+			if (this.commandIndex < 0) return CommandNoop("Nothing to undo");
+			const command = this.commandHistory[this.commandIndex];
+			if (!command.undo) return CommandNoop("Command cannot be undone");
 
-					this.internalEvents.emit(EditEvent.EditUndo, { command: command.name });
-					this.emitEditChanged(`undo:${command.name}`);
-				}
-			}
+			const context = this.createCommandContext();
+			// Always await - harmless on sync results, works across realms
+			const result = await Promise.resolve(command.undo(context));
+			// Only decrement after successful completion
+			this.commandIndex -= 1;
+
+			this.internalEvents.emit(EditEvent.EditUndo, { command: command.name });
+			this.emitEditChanged(`undo:${command.name}`);
+			return result;
 		});
 	}
 
-	public redo(): Promise<void> {
+	/**
+	 * Re-apply the most recently undone command.
+	 *
+	 * Resolves with the outcome: `success` when a command was re-applied, or `noop` (with
+	 * a `message`) when there is nothing to redo.
+	 */
+	public redo(): Promise<CommandResult> {
 		return this.commandQueue.enqueue(async () => {
-			if (this.commandIndex < this.commandHistory.length - 1) {
-				const nextIndex = this.commandIndex + 1;
-				const command = this.commandHistory[nextIndex];
-				const context = this.createCommandContext();
-				// Always await - harmless on sync results, works across realms
-				await Promise.resolve(command.execute(context));
-				// Only increment after successful completion
-				this.commandIndex = nextIndex;
+			if (this.commandIndex >= this.commandHistory.length - 1) return CommandNoop("Nothing to redo");
+			const nextIndex = this.commandIndex + 1;
+			const command = this.commandHistory[nextIndex];
+			const context = this.createCommandContext();
+			// Always await - harmless on sync results, works across realms
+			const result = await Promise.resolve(command.execute(context));
+			// Only increment after successful completion
+			this.commandIndex = nextIndex;
 
-				this.internalEvents.emit(EditEvent.EditRedo, { command: command.name });
-				this.emitEditChanged(`redo:${command.name}`);
-			}
+			this.internalEvents.emit(EditEvent.EditRedo, { command: command.name });
+			this.emitEditChanged(`redo:${command.name}`);
+			return result;
 		});
 	}
 	/** True when there is a command to undo (the history pointer is not before the first command). */
@@ -1142,11 +1180,17 @@ export class Edit {
 		this.emitEditChanged(`commit:${command.name}`);
 	}
 
-	public updateClip(trackIdx: number, clipIdx: number, updates: Partial<Clip>): Promise<void> {
+	/**
+	 * Merge `updates` into the clip at `(trackIdx, clipIdx)`.
+	 *
+	 * Resolves with the command outcome: `success` when the clip was updated, or `noop`
+	 * (with a `message`) when there is no clip at that position.
+	 */
+	public updateClip(trackIdx: number, clipIdx: number, updates: Partial<Clip>): Promise<CommandResult> {
 		const clip = this.getPlayerClip(trackIdx, clipIdx);
 		if (!clip) {
 			console.warn(`Clip not found at track ${trackIdx}, index ${clipIdx}`);
-			return Promise.resolve();
+			return Promise.resolve(CommandNoop(`No clip at track ${trackIdx}, index ${clipIdx}`));
 		}
 
 		const documentClip = this.document?.getClip(trackIdx, clipIdx);
@@ -1193,7 +1237,7 @@ export class Edit {
 	}
 
 	/** @internal */
-	public executeEditCommand(command: EditCommand): void | Promise<void> {
+	public executeEditCommand(command: EditCommand): Promise<CommandResult> {
 		return this.executeCommand(command);
 	}
 
@@ -1221,12 +1265,13 @@ export class Edit {
 	}
 
 	/** @internal */
-	protected executeCommand(command: EditCommand): Promise<void> {
+	protected executeCommand(command: EditCommand): Promise<CommandResult> {
 		return this.commandQueue.enqueue(async () => {
 			const context = this.createCommandContext();
 			// Always await - harmless on sync results, works across realms
 			const result = await Promise.resolve(command.execute(context));
 			this.handleCommandResult(command, result);
+			return result;
 		});
 	}
 
@@ -2074,12 +2119,12 @@ export class Edit {
 
 	// ─── Output Settings (delegated to OutputSettingsManager) ────────────────────
 
-	public setOutputSize(width: number, height: number): Promise<void> {
+	public setOutputSize(width: number, height: number): Promise<CommandResult> {
 		const command = new SetOutputSizeCommand(width, height);
 		return this.executeCommand(command);
 	}
 
-	public setOutputFps(fps: number): Promise<void> {
+	public setOutputFps(fps: number): Promise<CommandResult> {
 		const command = new SetOutputFpsCommand(fps);
 		return this.executeCommand(command);
 	}
@@ -2088,7 +2133,7 @@ export class Edit {
 		return this.outputSettings.getFps();
 	}
 
-	public setOutputFormat(format: string): Promise<void> {
+	public setOutputFormat(format: string): Promise<CommandResult> {
 		const command = new SetOutputFormatCommand(format);
 		return this.executeCommand(command);
 	}
@@ -2097,7 +2142,7 @@ export class Edit {
 		return this.outputSettings.getFormat();
 	}
 
-	public setOutputDestinations(destinations: Destination[]): Promise<void> {
+	public setOutputDestinations(destinations: Destination[]): Promise<CommandResult> {
 		const command = new SetOutputDestinationsCommand(destinations);
 		return this.executeCommand(command);
 	}
@@ -2106,7 +2151,7 @@ export class Edit {
 		return this.outputSettings.getDestinations();
 	}
 
-	public setOutputResolution(resolution: string): Promise<void> {
+	public setOutputResolution(resolution: string): Promise<CommandResult> {
 		const command = new SetOutputResolutionCommand(resolution);
 		return this.executeCommand(command);
 	}
@@ -2115,7 +2160,7 @@ export class Edit {
 		return this.outputSettings.getResolution();
 	}
 
-	public setOutputAspectRatio(aspectRatio: string): Promise<void> {
+	public setOutputAspectRatio(aspectRatio: string): Promise<CommandResult> {
 		const command = new SetOutputAspectRatioCommand(aspectRatio);
 		return this.executeCommand(command);
 	}
@@ -2262,7 +2307,7 @@ export class Edit {
 		this.cleanupUnusedFonts();
 	}
 
-	public setTimelineBackground(color: string): Promise<void> {
+	public setTimelineBackground(color: string): Promise<CommandResult> {
 		const command = new SetTimelineBackgroundCommand(color);
 		return this.executeCommand(command);
 	}

--- a/src/core/shotstack-edit.ts
+++ b/src/core/shotstack-edit.ts
@@ -1,4 +1,5 @@
 import { SetMergeFieldCommand } from "./commands/set-merge-field-command";
+import { CommandNoop, type CommandResult } from "./commands/types";
 import { Edit } from "./edit-session";
 import { EditEvent } from "./events/edit-events";
 import { parseFontFamily } from "./fonts/font-config";
@@ -101,7 +102,7 @@ export class ShotstackEdit extends Edit {
 	/**
 	 * Apply a merge field to a clip property.
 	 */
-	public applyMergeField(clipId: string, propertyPath: string, fieldName: string, value: string, originalValue?: string): Promise<void> {
+	public applyMergeField(clipId: string, propertyPath: string, fieldName: string, value: string, originalValue?: string): Promise<CommandResult> {
 		const resolvedClip = this.getResolvedClipById(clipId);
 		const currentValue = resolvedClip ? getNestedValue(resolvedClip, propertyPath) : null;
 		const previousValue = originalValue ?? (currentValue != null ? String(currentValue) : "");
@@ -118,9 +119,9 @@ export class ShotstackEdit extends Edit {
 	/**
 	 * Remove a merge field from a clip property, restoring the original value.
 	 */
-	public removeMergeField(clipId: string, propertyPath: string, restoreValue: string): Promise<void> {
+	public removeMergeField(clipId: string, propertyPath: string, restoreValue: string): Promise<CommandResult> {
 		const currentFieldName = this.getMergeFieldForProperty(clipId, propertyPath);
-		if (!currentFieldName) return Promise.resolve();
+		if (!currentFieldName) return Promise.resolve(CommandNoop("No merge field on this property"));
 
 		const command = new SetMergeFieldCommand(clipId, propertyPath, null, currentFieldName, restoreValue, restoreValue);
 		return this.executeCommand(command);

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,5 +9,6 @@ export { UIController } from "@core/ui/ui-controller";
 
 export type { UIControllerOptions, ToolbarButtonConfig } from "@core/ui/ui-controller";
 export type { EditConfig } from "@core/schemas";
+export type { CommandResult } from "@core/commands/types";
 
 export const VERSION = pkg.version;

--- a/tests/edit-clip-operations.test.ts
+++ b/tests/edit-clip-operations.test.ts
@@ -483,6 +483,72 @@ describe("Edit Clip Operations", () => {
 		});
 	});
 
+	describe("command results", () => {
+		it("deleteClip resolves noop when deleting the only clip", async () => {
+			// Only the initial image clip exists at this point
+			const result = await edit.deleteClip(0, 0);
+
+			expect(result).toEqual({ status: "noop", message: "Cannot delete the last clip" });
+			const { tracks } = getEditState(edit);
+			expect(tracks[0].length).toBe(1);
+		});
+
+		it("deleteClip resolves success when another clip remains", async () => {
+			await edit.addClip(0, createVideoClip(0, 5));
+
+			const result = await edit.deleteClip(0, 0);
+
+			expect(result.status).toBe("success");
+		});
+
+		it("deleteClip resolves noop for a missing position", async () => {
+			expect(await edit.deleteClip(99, 0)).toMatchObject({ status: "noop" });
+			expect(await edit.deleteClip(0, 99)).toMatchObject({ status: "noop" });
+		});
+
+		it("deleteClipById resolves noop for an unknown id", async () => {
+			const result = await edit.deleteClipById("not-a-real-clip-id");
+
+			expect(result).toEqual({ status: "noop", message: "No clip with id not-a-real-clip-id" });
+		});
+
+		it("updateClipById resolves noop for an unknown id", async () => {
+			const result = await edit.updateClipById("not-a-real-clip-id", {});
+
+			expect(result).toMatchObject({ status: "noop" });
+		});
+
+		it("addClip resolves success", async () => {
+			const result = await edit.addClip(0, createVideoClip(0, 5));
+
+			expect(result.status).toBe("success");
+		});
+
+		it("deleteTrack resolves noop when deleting the last track", async () => {
+			const result = await edit.deleteTrack(0);
+
+			expect(result).toEqual({ status: "noop", message: "Cannot delete the last track" });
+		});
+
+		it("undo resolves noop when the history is empty", async () => {
+			// load() builds the initial timeline without going through the command queue
+			expect(await edit.undo()).toEqual({ status: "noop", message: "Nothing to undo" });
+		});
+
+		it("undo resolves the undone command's outcome", async () => {
+			await edit.addClip(0, createVideoClip(0, 5));
+
+			expect((await edit.undo()).status).toBe("success");
+			expect(await edit.undo()).toEqual({ status: "noop", message: "Nothing to undo" });
+		});
+
+		it("redo resolves noop when there is nothing to redo", async () => {
+			const result = await edit.redo();
+
+			expect(result).toEqual({ status: "noop", message: "Nothing to redo" });
+		});
+	});
+
 	describe("updateClip()", () => {
 		beforeEach(async () => {
 			await edit.addClip(0, createTextClip(0, 5, "Original"));

--- a/tests/edit-clip-operations.test.ts
+++ b/tests/edit-clip-operations.test.ts
@@ -547,6 +547,71 @@ describe("Edit Clip Operations", () => {
 
 			expect(result).toEqual({ status: "noop", message: "Nothing to redo" });
 		});
+
+		it("redo resolves the re-applied command's outcome", async () => {
+			await edit.addClip(0, createVideoClip(0, 5));
+			await edit.undo();
+
+			expect((await edit.redo()).status).toBe("success");
+			expect(await edit.redo()).toEqual({ status: "noop", message: "Nothing to redo" });
+		});
+
+		it("moveClipById resolves noop for an unknown id", async () => {
+			const result = await edit.moveClipById("not-a-real-clip-id", 0);
+
+			expect(result).toEqual({ status: "noop", message: "No clip with id not-a-real-clip-id" });
+		});
+
+		it("deleteClipById resolves success for a real clip", async () => {
+			await edit.addClip(0, createVideoClip(0, 5));
+			const doc = (edit as unknown as { document: { getClipId(t: number, c: number): string | null } }).document;
+			const id = doc.getClipId(0, 1);
+			expect(id).toBeTruthy();
+
+			expect((await edit.deleteClipById(id as string)).status).toBe("success");
+		});
+
+		it("updateClip resolves success and noop by position", async () => {
+			expect((await edit.updateClip(0, 0, { fit: "contain" })).status).toBe("success");
+			expect(await edit.updateClip(0, 99, {})).toMatchObject({ status: "noop" });
+		});
+
+		it("deleteTrack resolves success when another track remains", async () => {
+			await edit.addTrack(1, { clips: [createVideoClip(0, 5)] });
+
+			expect((await edit.deleteTrack(1)).status).toBe("success");
+		});
+
+		it("setOutputSize resolves a command outcome", async () => {
+			expect((await edit.setOutputSize(1280, 720)).status).toBe("success");
+		});
+
+		it("deleteClip returns the requested clip's outcome when a luma matte shares the track", async () => {
+			// Track 0: [image (initial), luma, video]
+			await edit.addClip(0, { asset: { type: "luma", src: "https://example.com/matte.mp4" }, start: 0, length: 5 });
+			await edit.addClip(0, createVideoClip(0, 5));
+
+			// Deleting the video (a content clip) removes the track's luma first, then the video —
+			// the resolved outcome is the video's
+			const result = await edit.deleteClip(0, 2);
+
+			expect(result.status).toBe("success");
+			const { tracks } = getEditState(edit);
+			expect(tracks[0].length).toBe(1);
+		});
+
+		it("deleteClip refuses atomically when the content clip with a luma is the last one", async () => {
+			// Track 0: [image (initial), luma] — the image is the last content clip
+			await edit.addClip(0, { asset: { type: "luma", src: "https://example.com/matte.mp4" }, start: 0, length: 5 });
+
+			// The deletion is refused up front: the luma must NOT be deleted as a side
+			// effect of a refused operation
+			const result = await edit.deleteClip(0, 0);
+
+			expect(result).toEqual({ status: "noop", message: "Cannot delete the last clip" });
+			const { tracks } = getEditState(edit);
+			expect(tracks[0].length).toBe(2);
+		});
 	});
 
 	describe("updateClip()", () => {

--- a/tests/edit-merge-fields.test.ts
+++ b/tests/edit-merge-fields.test.ts
@@ -338,6 +338,21 @@ describe("Edit Merge Fields", () => {
 	});
 
 	describe("applyMergeField()", () => {
+		it("resolves a command outcome, and removeMergeField resolves noop when no field exists", async () => {
+			const clip = createImageClip(0, 3);
+			await edit.addClip(0, clip);
+			const clipId = getClipIdOrFail(edit, 0, 0);
+
+			// No merge field on the property yet — removal reports it did nothing
+			expect(await edit.removeMergeField(clipId, "asset.src", "restore")).toEqual({
+				status: "noop",
+				message: "No merge field on this property"
+			});
+
+			const applied = await edit.applyMergeField(clipId, "asset.src", "MEDIA_URL", "https://cdn.example.com/new.jpg");
+			expect(applied.status).toBe("success");
+		});
+
 		it("stores {{ FIELD }} template in document bindings", async () => {
 			// Add a clip first
 			const clip = createImageClip(0, 3);


### PR DESCRIPTION
## What

Commands have always distinguished a mutation that applied (`success`) from one that was refused or matched nothing (`noop`, e.g. deleting the last clip, an unknown clip id, undo on empty history) — but the public API flattened both to `Promise<void>`, so callers could not tell them apart. Deleting the only clip in the timeline, for example, resolved normally while the document stayed unchanged.

Mutators now resolve with the `CommandResult` (`{ status: "success" | "noop", message? }`), exported from the package root:

- `addClip`, `updateClip(ById)`, `deleteClip(ById)`, `moveClipById`, `addTrack`, `deleteTrack`
- `undo` / `redo` (`noop` when there is nothing to undo/redo)
- output setters (`setOutputSize/Fps/Format/Destinations/Resolution/AspectRatio`, `setTimelineBackground`)
- `applyMergeField` / `removeMergeField`
- unknown-id lookups now resolve `noop` with a message instead of only logging a console warning

`deleteTrack` previously returned `void` synchronously while the command ran on the queue; it now returns the queued result promise.

Also fixes a partial-mutation edge the new contract exposed: deleting a content clip that has a luma matte attached, when they are the last two clips, used to delete the luma and then refuse the content clip. The refusal is now atomic — a `noop` means nothing changed.

## Why

Programmatic callers (editor tooling, automation) need to know whether a mutation actually applied. Resolution no longer implies success — check `status`.

## Compatibility

Additive: existing callers that ignore the resolved value are unaffected. Timeline invariants are unchanged (always ≥1 clip and ≥1 track).

## Verify

`npm test` — 1833 tests pass, including new result-contract cases in `tests/edit-clip-operations.test.ts` and `tests/edit-merge-fields.test.ts` (last-clip refusal, atomic luma-path refusal, unknown ids, last track, undo/redo exhaustion, output setters, merge fields).