### PR TITLE
fix: cancel timeline clip interactions when the pointer stream is interrupted

### DIFF
--- a/src/components/timeline/interaction/interaction-controller.ts
+++ b/src/components/timeline/interaction/interaction-controller.ts
@@ -98,6 +98,7 @@ export interface TimelineInteractionRegistration {
 /** Controller for timeline interactions (drag, resize, selection) */
 export class InteractionController implements TimelineInteractionRegistration {
 	private state: InteractionState = IDLE_STATE;
+	private activePointerId = -1;
 	private readonly config: ResolvedConfig;
 	private snapPoints: SnapPoint[] = [];
 
@@ -108,6 +109,7 @@ export class InteractionController implements TimelineInteractionRegistration {
 	private readonly handlePointerDown: (e: PointerEvent) => void;
 	private readonly handlePointerMove: (e: PointerEvent) => void;
 	private readonly handlePointerUp: (e: PointerEvent) => void;
+	private readonly handlePointerCancel: (e: PointerEvent) => void;
 
 	constructor(
 		private readonly edit: Edit,
@@ -124,6 +126,7 @@ export class InteractionController implements TimelineInteractionRegistration {
 		this.handlePointerDown = this.onPointerDown.bind(this);
 		this.handlePointerMove = this.onPointerMove.bind(this);
 		this.handlePointerUp = this.onPointerUp.bind(this);
+		this.handlePointerCancel = this.onPointerCancel.bind(this);
 	}
 
 	// ═══════════════════════════════════════════════════════════════════════════
@@ -134,6 +137,7 @@ export class InteractionController implements TimelineInteractionRegistration {
 		this.tracksContainer.addEventListener("pointerdown", this.handlePointerDown);
 		document.addEventListener("pointermove", this.handlePointerMove);
 		document.addEventListener("pointerup", this.handlePointerUp);
+		document.addEventListener("pointercancel", this.handlePointerCancel);
 	}
 
 	public update(_deltaTime: number): void {
@@ -146,6 +150,9 @@ export class InteractionController implements TimelineInteractionRegistration {
 	}
 
 	private onPointerDown(e: PointerEvent): void {
+		if (e.button !== 0) return;
+		if (this.state.type !== "idle") this.cancelInteraction();
+
 		const target = e.target as HTMLElement;
 
 		// Find clip element
@@ -174,6 +181,7 @@ export class InteractionController implements TimelineInteractionRegistration {
 		const clip = this.stateManager.getClipAt(clipRef.trackIndex, clipRef.clipIndex);
 		if (!clip) return;
 
+		this.beginPointerInteraction(e);
 		this.state = createPendingState({ x: e.clientX, y: e.clientY }, clipRef, clip.config.start);
 	}
 
@@ -187,6 +195,7 @@ export class InteractionController implements TimelineInteractionRegistration {
 		) as HTMLElement | null;
 		if (!clipElement) return;
 
+		this.beginPointerInteraction(e);
 		this.state = createResizingState(clipRef, clipElement, edge, clip.config.start, clip.config.length);
 
 		this.buildSnapPointsForClip(clipRef);
@@ -194,7 +203,26 @@ export class InteractionController implements TimelineInteractionRegistration {
 		e.preventDefault();
 	}
 
+	/** Track the pointer driving this interaction and capture it so its pointerup cannot be lost */
+	private beginPointerInteraction(e: PointerEvent): void {
+		this.activePointerId = e.pointerId;
+		try {
+			this.tracksContainer.setPointerCapture(e.pointerId);
+		} catch {
+			// pointer already released
+		}
+	}
+
 	private onPointerMove(e: PointerEvent): void {
+		if (this.state.type === "idle" || e.pointerId !== this.activePointerId) return;
+
+		// Primary button no longer held: the pointerup was lost (native menu, app switch) - cancel
+		if ((e.buttons & 1) === 0) {
+			// eslint-disable-line no-bitwise -- PointerEvent.buttons is a bitmask
+			this.cancelInteraction();
+			return;
+		}
+
 		switch (this.state.type) {
 			case "pending":
 				this.handlePendingMove(e, this.state);
@@ -223,7 +251,7 @@ export class InteractionController implements TimelineInteractionRegistration {
 		const { clipRef } = state;
 		const clip = this.stateManager.getClipAt(clipRef.trackIndex, clipRef.clipIndex);
 		if (!clip) {
-			this.state = IDLE_STATE;
+			this.setIdle();
 			return;
 		}
 
@@ -232,7 +260,7 @@ export class InteractionController implements TimelineInteractionRegistration {
 			`[data-track-index="${clipRef.trackIndex}"][data-clip-index="${clipRef.clipIndex}"]`
 		) as HTMLElement | null;
 		if (!clipElement) {
-			this.state = IDLE_STATE;
+			this.setIdle();
 			return;
 		}
 
@@ -484,10 +512,12 @@ export class InteractionController implements TimelineInteractionRegistration {
 	}
 
 	private onPointerUp(e: PointerEvent): void {
+		if (this.state.type === "idle" || e.pointerId !== this.activePointerId || e.button !== 0) return;
+
 		switch (this.state.type) {
 			case "pending":
 				// Was just a click, selection already handled
-				this.state = IDLE_STATE;
+				this.setIdle();
 				break;
 			case "dragging":
 				this.completeDrag(e, this.state);
@@ -498,6 +528,37 @@ export class InteractionController implements TimelineInteractionRegistration {
 			default:
 				break;
 		}
+	}
+
+	private onPointerCancel(e: PointerEvent): void {
+		if (this.state.type === "idle" || e.pointerId !== this.activePointerId) return;
+		this.cancelInteraction();
+	}
+
+	/** Abandon the current interaction without executing any command */
+	private cancelInteraction(): void {
+		if (this.state.type === "dragging") this.cancelDrag(this.state);
+		else if (this.state.type === "resizing") this.cancelResize(this.state);
+		this.setIdle();
+	}
+
+	private cancelDrag(state: DraggingState): void {
+		restoreClipElementStyles(state.clipElement, state.originalStyles);
+		state.ghost.remove();
+		this.feedbackElements = clearAllFeedback(this.feedbackElements, state.clipElement);
+	}
+
+	private cancelResize(state: ResizingState): void {
+		const { clipElement, originalStart, originalLength } = state;
+		clipElement.style.setProperty("--clip-start", String(originalStart));
+		clipElement.style.setProperty("--clip-length", String(originalLength));
+		hideSnapLine(this.feedbackElements.snapLine);
+		hideDragTimeTooltip(this.feedbackElements.dragTimeTooltip);
+	}
+
+	private setIdle(): void {
+		this.state = IDLE_STATE;
+		this.activePointerId = -1;
 	}
 
 	private completeDrag(_e: PointerEvent, state: DraggingState): void {
@@ -532,7 +593,7 @@ export class InteractionController implements TimelineInteractionRegistration {
 		// 4. Cleanup
 		ghost.remove();
 		this.feedbackElements = clearAllFeedback(this.feedbackElements, clipElement);
-		this.state = IDLE_STATE;
+		this.setIdle();
 	}
 
 	private executeDropAction(state: DraggingState, action: DropAction, targetClip: ClipState | null, existingLumaRef: ClipRef | null): void {
@@ -769,7 +830,7 @@ export class InteractionController implements TimelineInteractionRegistration {
 		// Cleanup
 		hideSnapLine(this.feedbackElements.snapLine);
 		hideDragTimeTooltip(this.feedbackElements.dragTimeTooltip);
-		this.state = IDLE_STATE;
+		this.setIdle();
 	}
 
 	private moveLumaWithContent(lumaPlayer: ReturnType<TimelineStateManager["getAttachedLumaPlayer"]>, targetTrack: number, newTime: number): void {
@@ -859,9 +920,12 @@ export class InteractionController implements TimelineInteractionRegistration {
 	}
 
 	public dispose(): void {
+		this.cancelInteraction();
+
 		this.tracksContainer.removeEventListener("pointerdown", this.handlePointerDown);
 		document.removeEventListener("pointermove", this.handlePointerMove);
 		document.removeEventListener("pointerup", this.handlePointerUp);
+		document.removeEventListener("pointercancel", this.handlePointerCancel);
 
 		// Dispose all feedback elements (stateless, idempotent)
 		disposeFeedbackElements(this.feedbackElements);

--- a/src/components/timeline/interaction/interaction-controller.ts
+++ b/src/components/timeline/interaction/interaction-controller.ts
@@ -217,8 +217,8 @@ export class InteractionController implements TimelineInteractionRegistration {
 		if (this.state.type === "idle" || e.pointerId !== this.activePointerId) return;
 
 		// Primary button no longer held: the pointerup was lost (native menu, app switch) - cancel
+		// eslint-disable-next-line no-bitwise -- PointerEvent.buttons is a bitmask
 		if ((e.buttons & 1) === 0) {
-			// eslint-disable-line no-bitwise -- PointerEvent.buttons is a bitmask
 			this.cancelInteraction();
 			return;
 		}

--- a/src/styles/timeline/timeline.css
+++ b/src/styles/timeline/timeline.css
@@ -287,6 +287,7 @@
 	border-radius: 4px;
 	cursor: grab;
 	overflow: hidden;
+	touch-action: none;
 	transition:
 		box-shadow 0.15s ease,
 		transform 0.1s ease;

--- a/tests/interaction-controller.test.ts
+++ b/tests/interaction-controller.test.ts
@@ -221,6 +221,9 @@ function createPointerEvent(
 		shiftKey?: boolean;
 		ctrlKey?: boolean;
 		metaKey?: boolean;
+		button?: number;
+		buttons?: number;
+		pointerId?: number;
 	} = {}
 ): Event {
 	// Create a custom event with pointer event properties
@@ -230,14 +233,18 @@ function createPointerEvent(
 		cancelable: true
 	});
 
-	// Add pointer/mouse event properties
+	// Add pointer/mouse event properties (primary button held by default, released on pointerup/cancel)
+	const defaultButtons = type === "pointerup" || type === "pointercancel" ? 0 : 1;
 	Object.defineProperties(event, {
 		clientX: { value: options.clientX ?? 0, writable: false },
 		clientY: { value: options.clientY ?? 0, writable: false },
 		altKey: { value: options.altKey ?? false, writable: false },
 		shiftKey: { value: options.shiftKey ?? false, writable: false },
 		ctrlKey: { value: options.ctrlKey ?? false, writable: false },
-		metaKey: { value: options.metaKey ?? false, writable: false }
+		metaKey: { value: options.metaKey ?? false, writable: false },
+		button: { value: options.button ?? 0, writable: false },
+		buttons: { value: options.buttons ?? defaultButtons, writable: false },
+		pointerId: { value: options.pointerId ?? 1, writable: false }
 	});
 
 	// Override target if provided
@@ -781,6 +788,7 @@ describe("InteractionController", () => {
 			expect(tracksRemoveSpy).toHaveBeenCalledWith("pointerdown", expect.any(Function));
 			expect(docRemoveSpy).toHaveBeenCalledWith("pointermove", expect.any(Function));
 			expect(docRemoveSpy).toHaveBeenCalledWith("pointerup", expect.any(Function));
+			expect(docRemoveSpy).toHaveBeenCalledWith("pointercancel", expect.any(Function));
 		});
 
 		it("removes feedback elements on dispose", () => {
@@ -1049,6 +1057,141 @@ describe("InteractionController", () => {
 
 			// Should be dragging with default threshold
 			expect(controller.isDragging(0, 0)).toBe(true);
+		});
+	});
+
+	// ─── Interrupted Interaction Tests ───────────────────────────────────────
+
+	describe("interrupted interactions", () => {
+		const createController = () => {
+			controller = new InteractionController(
+				mockEdit as never,
+				mockStateManager as never,
+				mockTrackList as never,
+				mockDOM.tracksContainer,
+				mockDOM.feedbackLayer
+			);
+			controller.mount();
+		};
+
+		const startDrag = (clipElement: HTMLElement) => {
+			clipElement.dispatchEvent(createPointerEvent("pointerdown", { clientX: 50, clientY: 20 }));
+			document.dispatchEvent(createPointerEvent("pointermove", { clientX: 100, clientY: 20 }));
+		};
+
+		it("cancels drag on pointercancel, restoring the clip without executing commands", () => {
+			createController();
+			const clipElement = mockDOM.tracksContainer.querySelector(".ss-clip") as HTMLElement;
+
+			startDrag(clipElement);
+			expect(controller.isDragging(0, 0)).toBe(true);
+			expect(clipElement.style.position).toBe("fixed");
+
+			document.dispatchEvent(createPointerEvent("pointercancel", { clientX: 100, clientY: 20 }));
+
+			expect(controller.isDragging(0, 0)).toBe(false);
+			expect(clipElement.style.position).toBe("");
+			expect(mockDOM.feedbackLayer.querySelector(".ss-drag-ghost")).toBeNull();
+			expect(mockEdit.executeEditCommand).not.toHaveBeenCalled();
+		});
+
+		it("cancels drag when a move arrives with no button held (lost pointerup)", () => {
+			createController();
+			const clipElement = mockDOM.tracksContainer.querySelector(".ss-clip") as HTMLElement;
+
+			startDrag(clipElement);
+			expect(controller.isDragging(0, 0)).toBe(true);
+
+			document.dispatchEvent(createPointerEvent("pointermove", { clientX: 300, clientY: 20, buttons: 0 }));
+
+			expect(controller.isDragging(0, 0)).toBe(false);
+			expect(clipElement.style.position).toBe("");
+			expect(mockEdit.executeEditCommand).not.toHaveBeenCalled();
+		});
+
+		it("ignores non-primary-button pointerdown", () => {
+			createController();
+			const clipElement = mockDOM.tracksContainer.querySelector(".ss-clip") as HTMLElement;
+
+			clipElement.dispatchEvent(createPointerEvent("pointerdown", { clientX: 50, clientY: 20, button: 2, buttons: 2 }));
+			document.dispatchEvent(createPointerEvent("pointermove", { clientX: 100, clientY: 20, buttons: 2 }));
+
+			expect(controller.isDragging(0, 0)).toBe(false);
+			expect(clipElement.style.position).toBe("");
+		});
+
+		it("keeps dragging when a non-primary button is released mid-drag", () => {
+			createController();
+			const clipElement = mockDOM.tracksContainer.querySelector(".ss-clip") as HTMLElement;
+
+			startDrag(clipElement);
+			document.dispatchEvent(createPointerEvent("pointerup", { clientX: 100, clientY: 20, button: 2, buttons: 1 }));
+			expect(controller.isDragging(0, 0)).toBe(true);
+
+			document.dispatchEvent(createPointerEvent("pointerup", { clientX: 100, clientY: 20 }));
+			expect(controller.isDragging(0, 0)).toBe(false);
+		});
+
+		it("ignores moves and ups from other pointers during a drag", () => {
+			createController();
+			const clipElement = mockDOM.tracksContainer.querySelector(".ss-clip") as HTMLElement;
+
+			startDrag(clipElement);
+			const leftBefore = clipElement.style.left;
+
+			document.dispatchEvent(createPointerEvent("pointermove", { clientX: 500, clientY: 20, pointerId: 7 }));
+			expect(clipElement.style.left).toBe(leftBefore);
+
+			document.dispatchEvent(createPointerEvent("pointerup", { clientX: 500, clientY: 20, pointerId: 7 }));
+			expect(controller.isDragging(0, 0)).toBe(true);
+		});
+
+		it("cancels a stale drag cleanly when a new pointerdown arrives", () => {
+			createController();
+			const clips = mockDOM.tracksContainer.querySelectorAll(".ss-clip");
+			const firstClip = clips[0] as HTMLElement;
+			const secondClip = clips[1] as HTMLElement;
+
+			startDrag(firstClip);
+			expect(firstClip.style.position).toBe("fixed");
+
+			// Pointerup was lost; user presses again on another clip
+			secondClip.dispatchEvent(createPointerEvent("pointerdown", { clientX: 250, clientY: 20 }));
+
+			expect(firstClip.style.position).toBe("");
+			expect(mockDOM.feedbackLayer.querySelector(".ss-drag-ghost")).toBeNull();
+			expect(controller.isDragging(0, 0)).toBe(false);
+			expect(mockEdit.executeEditCommand).not.toHaveBeenCalled();
+		});
+
+		it("cancels resize on pointercancel, restoring clip timing vars", () => {
+			createController();
+			const clipElement = mockDOM.tracksContainer.querySelector(".ss-clip") as HTMLElement;
+			const handle = clipElement.querySelector(".ss-clip-resize-handle.right") as HTMLElement;
+
+			handle.dispatchEvent(createPointerEvent("pointerdown", { clientX: 195, clientY: 20 }));
+			document.dispatchEvent(createPointerEvent("pointermove", { clientX: 300, clientY: 20 }));
+			expect(controller.isResizing(0, 0)).toBe(true);
+			expect(clipElement.style.getPropertyValue("--clip-length")).not.toBe("2");
+
+			document.dispatchEvent(createPointerEvent("pointercancel", {}));
+
+			expect(controller.isResizing(0, 0)).toBe(false);
+			expect(clipElement.style.getPropertyValue("--clip-length")).toBe("2");
+			expect(mockEdit.executeEditCommand).not.toHaveBeenCalled();
+		});
+
+		it("restores an in-flight drag when disposed mid-drag", () => {
+			createController();
+			const clipElement = mockDOM.tracksContainer.querySelector(".ss-clip") as HTMLElement;
+
+			startDrag(clipElement);
+			expect(clipElement.style.position).toBe("fixed");
+
+			controller.dispose();
+
+			expect(clipElement.style.position).toBe("");
+			expect(mockDOM.feedbackLayer.querySelector(".ss-drag-ghost")).toBeNull();
 		});
 	});
 });


### PR DESCRIPTION
## What

A timeline clip drag could stick to the cursor. If the browser never delivered `pointerup` (for example, releasing over a native context menu, switching apps mid-drag, or a touch scroll takeover), the interaction state machine remained in `dragging`, so every subsequent hover move kept repositioning the clip. Clicking to recover could start a new interaction over the stale one, leaving the clip stranded at `position: fixed` with `pointer-events: none` until a re-render.

## How

- Only the primary button starts drags, resizes, and selection clears
- The tracks container captures the pointer, so the release is delivered even outside the window
- `pointercancel`, or any move without the primary button held, cancels the interaction: the clip is restored to its original position, the ghost is removed, and no command is executed
- A stale interaction is cancelled before a new pointerdown starts one, and on `dispose()`
- Events are filtered by pointer id, so a second touch cannot drive or complete another pointer's drag
- `touch-action: none` on clips stops the browser from reclaiming touch drags for scrolling (empty track area still scrolls)

## Verify

Normal drag/drop/resize behaviour is unchanged: 29 unit tests (8 new), plus drag-and-drop and drag-cancel exercised in-browser on this branch. To reproduce the lost `pointerup` deterministically, paste this in the console on any page showing the timeline — no manual dragging needed:

```js
await (async () => {
  const sleep = ms => new Promise(r => setTimeout(r, ms));
  const clips = [...document.querySelectorAll(".ss-clip")];
  const clip = clips[1] || clips[0];
  if (!clip) return console.log("no .ss-clip found");
  const rect = clip.getBoundingClientRect();
  const opt = (x, y, buttons) => ({ bubbles: true, pointerId: 1, isPrimary: true, button: 0, buttons, clientX: x, clientY: y });
  const x = rect.left + Math.min(40, rect.width / 2), y = rect.top + rect.height / 2;
  clip.dispatchEvent(new PointerEvent("pointerdown", opt(x, y, 1)));
  for (let i = 1; i <= 6; i++) { document.dispatchEvent(new PointerEvent("pointermove", opt(x + i * 30, y - i * 25, 1))); await sleep(20); }
  // the release is never dispatched — same as a pointerup eaten by a native menu or app switch
  document.dispatchEvent(new PointerEvent("pointermove", opt(x + 400, y - 300, 0)));
  await sleep(30);
  console.log(clips.some(c => c.style.position === "fixed")
    ? "BUG: clip is glued to the cursor — move the mouse to watch it follow; click to force a drop"
    : "FIXED: drag self-cancelled and the clip was restored");
})();
```

Verified on 2.13.0: prints BUG and the clip visibly chases the real mouse. On this branch: prints FIXED and the clip snaps back to its original position with no edit applied.
