### PR TITLE
fix: update @shotstack/schemas to 1.14.0 and handle srcless generated assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
 		"vite-plugin-dts": "^4.5.4"
 	},
 	"dependencies": {
-		"@shotstack/schemas": "1.11.0",
+		"@shotstack/schemas": "1.14.0",
 		"@shotstack/shotstack-canvas": "^2.10.0",
 		"howler": "^2.2.4",
 		"mediabunny": "^1.11.2",

--- a/src/components/canvas/players/audio-player.ts
+++ b/src/components/canvas/players/audio-player.ts
@@ -30,6 +30,10 @@ export class AudioPlayer extends Player {
 		const audioClipConfiguration = this.clipConfiguration.asset as AudioAsset;
 
 		const identifier = audioClipConfiguration.src;
+		if (!identifier) {
+			// Prompt-driven audio has no src until it's generated — fail this clip's load, not the edit
+			throw new Error("Audio asset has no src to load.");
+		}
 		const loadOptions: pixi.UnresolvedAsset = { src: identifier, parser: AudioLoadParser.Name };
 		const audioResource = await this.edit.assetLoader.load<howler.Howl>(identifier, loadOptions);
 
@@ -123,6 +127,9 @@ export class AudioPlayer extends Player {
 		this.syncTimer = 0;
 
 		const audioAsset = this.clipConfiguration.asset as AudioAsset;
+		if (!audioAsset.src) {
+			throw new Error("Audio asset has no src to load.");
+		}
 		const loadOptions: pixi.UnresolvedAsset = { src: audioAsset.src, parser: AudioLoadParser.Name };
 		const audioResource = await this.edit.assetLoader.load<howler.Howl>(audioAsset.src, loadOptions);
 

--- a/src/components/canvas/players/image-player.ts
+++ b/src/components/canvas/players/image-player.ts
@@ -86,6 +86,10 @@ export class ImagePlayer extends Player {
 	private async loadTexture(): Promise<void> {
 		const imageAsset = this.clipConfiguration.asset as ImageAsset;
 		const { src } = imageAsset;
+		if (!src) {
+			// Prompt-driven images have no src until they're generated — fail this clip's load, not the edit
+			throw new Error("Image asset has no src to load.");
+		}
 
 		const corsUrl = `${src}${src.includes("?") ? "&" : "?"}x-cors=1`;
 		const loadOptions: pixi.UnresolvedAsset = { src: corsUrl, crossorigin: "anonymous", data: {} };

--- a/src/components/canvas/players/video-player.ts
+++ b/src/components/canvas/players/video-player.ts
@@ -168,6 +168,10 @@ export class VideoPlayer extends Player {
 	private async loadVideo(): Promise<void> {
 		const videoAsset = this.clipConfiguration.asset as VideoAsset;
 		const { src } = videoAsset;
+		if (!src) {
+			// Generated video assets have no src until they're rendered — fail this clip's load, not the edit
+			throw new Error("Video asset has no src to load.");
+		}
 
 		if (src.endsWith(".mov")) {
 			throw new Error(`Video source '${src}' is not supported. .mov files cannot be played in the browser. Please convert to .webm or .mp4 first.`);

--- a/src/components/timeline/media-thumbnail-renderer.ts
+++ b/src/components/timeline/media-thumbnail-renderer.ts
@@ -127,6 +127,9 @@ export class MediaThumbnailRenderer implements ClipRenderer {
 		this.clipStates.set(clipKey, state);
 
 		try {
+			if (!asset.src) {
+				throw new Error("Video asset has no src for thumbnail generation.");
+			}
 			const result = await this.generator.generateThumbnail(asset.src, asset.trim ?? 0);
 
 			// Check if element is still in DOM (might have been disposed)
@@ -156,6 +159,9 @@ export class MediaThumbnailRenderer implements ClipRenderer {
 		this.clipStates.set(clipKey, state);
 
 		try {
+			if (!asset.src) {
+				throw new Error("Image asset has no src for thumbnail generation.");
+			}
 			const result = await this.loadImageThumbnail(asset.src);
 
 			// Check if element is still in DOM (might have been disposed)

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -387,3 +387,39 @@ describe("Real-world Use Cases", () => {
 		expect(result.success).toBe(true);
 	});
 });
+
+describe("API-accepted templates parse at load", () => {
+	// Templates created via the render API (e.g. by the MCP server) must open in the
+	// editor. These shapes were rejected by the previously pinned schemas version.
+	it("accepts text-to-speech assets with the newscaster option", () => {
+		const result = ClipSchema.safeParse({
+			asset: { type: "text-to-speech", text: "Tonight's headlines", voice: "Matthew", newscaster: true },
+			start: 0,
+			length: 5
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("accepts prompt-driven audio assets with voice and newscaster", () => {
+		const result = ClipSchema.safeParse({
+			asset: { type: "audio", prompt: "Read the news intro", voice: "Joanna", newscaster: true },
+			start: 0,
+			length: 5
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("accepts a destination without an options object", () => {
+		const result = EditSchema.safeParse({
+			timeline: {
+				tracks: [{ clips: [{ asset: { type: "image", src: "https://example.com/a.jpg" }, start: 0, length: 3 }] }]
+			},
+			output: {
+				size: { width: 1280, height: 720 },
+				format: "mp4",
+				destinations: [{ provider: "shotstack" }]
+			}
+		});
+		expect(result.success).toBe(true);
+	});
+});


### PR DESCRIPTION
## What changed

The schemas dependency was pinned to 1.11.0, so the editor validated edits against a contract several versions behind the render API. Templates using newer API features — the `newscaster` voice option on audio assets, prompt-driven audio (`prompt`/`voice`/`model`) — failed strict validation at load and could not be opened in the editor, even though they render fine via the API.

- Bump `@shotstack/schemas` 1.11.0 → 1.14.0 so load-time validation matches the current API contract.
- The newer contract makes `src` optional on audio, image, and video assets (generation-driven assets have no source until generated). Players and the thumbnail renderer now throw a clear per-clip error for a srcless asset instead of failing on `undefined` — clip load failures are already caught per clip, so the edit still opens with the affected clip flagged.

## How to verify

New tests in `tests/schema.test.ts` ("API-accepted templates parse at load"): text-to-speech and prompt-driven audio assets with `newscaster` parse successfully (the audio case fails on 1.11.0), and a destination without an options object is accepted. Full suite passes (1847 tests), tsc and lint clean, build succeeds.