### PR TITLE
fix: throw WebGLUnsupportedError when WebGL is unavailable

### DIFF
--- a/src/components/canvas/shotstack-canvas.ts
+++ b/src/components/canvas/shotstack-canvas.ts
@@ -5,7 +5,7 @@ import { Edit } from "@core/edit-session";
 import { InternalEvent } from "@core/events/edit-events";
 import { ms } from "@core/timing/types";
 import type { UIController } from "@core/ui/ui-controller";
-import { checkWebGLSupport } from "@core/webgl-support";
+import { checkWebGLSupport, WebGLUnsupportedError } from "@core/webgl-support";
 import { type Size } from "@layouts/geometry";
 import { AudioLoadParser } from "@loaders/audio-load-parser";
 import { FontLoadParser } from "@loaders/font-load-parser";
@@ -90,7 +90,7 @@ export class Canvas {
 		const webglSupport = checkWebGLSupport();
 		if (!webglSupport.supported) {
 			createWebGLErrorOverlay(root);
-			return;
+			throw new WebGLUnsupportedError(webglSupport.reason);
 		}
 
 		const rect = root.getBoundingClientRect();
@@ -268,6 +268,9 @@ export class Canvas {
 	}
 
 	public resize(): void {
+		// Renderer is undefined until load() initialises it and null after dispose().
+		if (!this.application.renderer) return;
+
 		const root = document.querySelector<HTMLDivElement>(Canvas.CanvasSelector);
 		if (!root) return;
 

--- a/src/core/webgl-support.ts
+++ b/src/core/webgl-support.ts
@@ -11,6 +11,21 @@ export interface WebGLSupportResult {
 }
 
 /**
+ * Thrown by `Canvas.load()` when WebGL is unavailable, so hosts can show
+ * their own error state instead of treating the editor as loaded.
+ */
+export class WebGLUnsupportedError extends Error {
+	constructor(reason?: WebGLSupportResult["reason"]) {
+		super(
+			reason === "webgl-error"
+				? "WebGL initialisation failed. The editor cannot render in this browser."
+				: "WebGL is not available in this browser. Enable hardware acceleration or use a browser that supports WebGL."
+		);
+		this.name = "WebGLUnsupportedError";
+	}
+}
+
+/**
  * Check if WebGL is available in the current browser.
  * Tests both WebGL2 and WebGL1 for maximum compatibility.
  */

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export { Controls } from "@core/inputs/controls";
 export { VideoExporter } from "@core/export";
 export { Timeline } from "@timeline/index";
 export { UIController } from "@core/ui/ui-controller";
+export { WebGLUnsupportedError } from "@core/webgl-support";
 
 export type { UIControllerOptions, ToolbarButtonConfig } from "@core/ui/ui-controller";
 export type { EditConfig } from "@core/schemas";

--- a/tests/webgl-support.test.ts
+++ b/tests/webgl-support.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ *
+ * WebGL Support Tests
+ *
+ * jsdom has no WebGL, so the unsupported path is the natural one here:
+ * load() must throw WebGLUnsupportedError (not silently succeed), and
+ * resize() must be a no-op before the renderer exists.
+ */
+
+import { Canvas } from "@canvas/shotstack-canvas";
+import { checkWebGLSupport, WebGLUnsupportedError } from "@core/webgl-support";
+
+import type { Edit } from "@core/edit-session";
+
+// pixi.js ships untransformed ESM that jest can't parse; the paths under test
+// (constructor + the WebGL guard at the top of load/resize) never reach a real renderer.
+jest.mock("pixi.js", () => ({
+	Application: jest.fn(),
+	Container: jest.fn(),
+	Graphics: jest.fn(),
+	Rectangle: jest.fn()
+}));
+jest.mock("pixi.js/app", () => ({}));
+jest.mock("pixi.js/events", () => ({}));
+jest.mock("pixi.js/graphics", () => ({}));
+jest.mock("pixi.js/text", () => ({}));
+jest.mock("pixi.js/text-html", () => ({}));
+jest.mock("pixi.js/sprite-tiling", () => ({}));
+jest.mock("pixi.js/filters", () => ({}));
+jest.mock("pixi.js/mesh", () => ({}));
+
+const makeEditStub = (): Edit =>
+	({
+		setCanvas: () => {},
+		size: { width: 1280, height: 720 }
+	}) as unknown as Edit;
+
+describe("WebGL support", () => {
+	beforeEach(() => {
+		document.body.innerHTML = `<div data-shotstack-studio></div>`;
+	});
+
+	it("reports unsupported in jsdom", () => {
+		expect(checkWebGLSupport().supported).toBe(false);
+	});
+
+	it("load() throws WebGLUnsupportedError when WebGL is unavailable", async () => {
+		const canvas = new Canvas(makeEditStub());
+		await expect(canvas.load()).rejects.toBeInstanceOf(WebGLUnsupportedError);
+	});
+
+	it("still renders the error overlay for the user", async () => {
+		const canvas = new Canvas(makeEditStub());
+		await canvas.load().catch(() => {});
+		const root = document.querySelector("[data-shotstack-studio]");
+		expect(root?.childElementCount).toBeGreaterThan(0);
+	});
+
+	it("resize() is a no-op before the renderer is initialised", () => {
+		const canvas = new Canvas(makeEditStub());
+		expect(() => canvas.resize()).not.toThrow();
+	});
+});


### PR DESCRIPTION
## What changed

- `Canvas.load()` now throws a typed `WebGLUnsupportedError` (exported from the package root) when WebGL is unavailable, instead of resolving successfully. The in-canvas error overlay still renders before the throw, so integrations that don't catch keep the current visual behaviour.
- `Canvas.resize()` is now a no-op when the renderer doesn't exist (before `load()` completes or after `dispose()`), instead of throwing `TypeError: Cannot read properties of undefined (reading 'resize')`.

## Why

When WebGL is unavailable (hardware acceleration disabled, some VMs/remote desktops), `load()` silently returned with no renderer. Hosts had no way to detect the failure, treated the editor as loaded, and any subsequent `resize()` call crashed. Hosts can now catch `WebGLUnsupportedError` and show their own error state.

## Behaviour change

`load()` rejects where it previously resolved on WebGL-less browsers. Integrations that relied on the silent overlay are unaffected visually, but code awaiting `load()` should handle the rejection.

## How to verify

`npx jest tests/webgl-support.test.ts` — jsdom has no WebGL, so the tests exercise the real failure path: `load()` rejects with `WebGLUnsupportedError`, the overlay still mounts, and `resize()` no-ops without a renderer.