### PR TITLE
Bump @shotstack/schemas to 1.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
 		"vite-plugin-dts": "^4.5.4"
 	},
 	"dependencies": {
-		"@shotstack/schemas": "1.14.0",
+		"@shotstack/schemas": "1.14.1",
 		"@shotstack/shotstack-canvas": "^2.10.2",
 		"howler": "^2.2.4",
 		"mediabunny": "^1.11.2",


### PR DESCRIPTION
Picks up schemas 1.14.1, which makes the google-drive destination `options` (and `folderId`) optional to match platform behaviour — files save to the My Drive root when omitted. Templates with an options-less google-drive destination now pass `editSchema` and load in the editor.

Verify: `pnpm test` (1872 tests) and `pnpm build` both pass.