### PR TITLE
fix: defer timeline pointer capture until drag starts so clip child clicks work

### DIFF
--- a/src/components/timeline/interaction/interaction-controller.ts
+++ b/src/components/timeline/interaction/interaction-controller.ts
@@ -181,7 +181,10 @@ export class InteractionController implements TimelineInteractionRegistration {
 		const clip = this.stateManager.getClipAt(clipRef.trackIndex, clipRef.clipIndex);
 		if (!clip) return;
 
-		this.beginPointerInteraction(e);
+		// No pointer capture yet: capturing retargets the eventual click event to
+		// the tracks container, which would break click handlers on clip children
+		// (e.g. the mask badge). Capture happens if this becomes a real drag.
+		this.activePointerId = e.pointerId;
 		this.state = createPendingState({ x: e.clientX, y: e.clientY }, clipRef, clip.config.start);
 	}
 
@@ -297,6 +300,7 @@ export class InteractionController implements TimelineInteractionRegistration {
 		const ghost = createDragGhost(clip.config.length, clipAssetType, sourceTrackHeight, pps);
 		this.feedbackElements.container.appendChild(ghost);
 
+		this.beginPointerInteraction(e);
 		this.state = createDraggingState(state, clipElement, ghost, dragOffsetX, dragOffsetY, originalStyles, clip.config.length, e.altKey);
 
 		// Position ghost at current clip position initially

--- a/tests/interaction-controller.test.ts
+++ b/tests/interaction-controller.test.ts
@@ -1079,6 +1079,22 @@ describe("InteractionController", () => {
 			document.dispatchEvent(createPointerEvent("pointermove", { clientX: 100, clientY: 20 }));
 		};
 
+		it("captures the pointer only when a drag starts, not on plain pointerdown", () => {
+			createController();
+			const clipElement = mockDOM.tracksContainer.querySelector(".ss-clip") as HTMLElement;
+			const setPointerCapture = jest.fn();
+			mockDOM.tracksContainer.setPointerCapture = setPointerCapture;
+
+			// Plain pointerdown (a click on the clip or a child like the mask badge)
+			// must not capture, or the resulting click event retargets away from the child
+			clipElement.dispatchEvent(createPointerEvent("pointerdown", { clientX: 50, clientY: 20 }));
+			expect(setPointerCapture).not.toHaveBeenCalled();
+
+			document.dispatchEvent(createPointerEvent("pointermove", { clientX: 100, clientY: 20 }));
+			expect(controller.isDragging(0, 0)).toBe(true);
+			expect(setPointerCapture).toHaveBeenCalled();
+		});
+
 		it("cancels drag on pointercancel, restoring the clip without executing commands", () => {
 			createController();
 			const clipElement = mockDOM.tracksContainer.querySelector(".ss-clip") as HTMLElement;


### PR DESCRIPTION
## What

Clicking the luma mask badge on a timeline clip no longer detached the mask. Capturing the pointer to the tracks container on every clip pointerdown retargets the derived `click` event away from clip children, so the badge's click handler never fired.

Pointer capture now happens only when a gesture commits: immediately for resize, and at the drag threshold for drags. Plain clicks flow to clip children untouched.

## Why it's safe

The interruption handling that introduced the capture is preserved: `pointercancel` and the lost-pointerup `buttons` check are unchanged, and drag/resize (the only states with visible stuck-clip risk) still capture. A lost pointerup during the pending state has no visual side effects and is cleared by the existing cancel paths. All six interruption tests pass unchanged.

## Verify

- New test: no capture on plain pointerdown, capture once the drag threshold is crossed.
- Manual: attach a luma to a clip, click the ◐ badge → mask detaches to a new track. Drag a clip and release outside the window → no stuck clip.