### PR TITLE
test: cover keyframe value predicates and assert committed slider state

### DIFF
--- a/tests/clip-utils.test.ts
+++ b/tests/clip-utils.test.ts
@@ -1,0 +1,46 @@
+import { hasKeyframedVisualProperty, isKeyframedValue } from "@core/shared/clip-utils";
+import type { Clip } from "@schemas";
+
+const tween = [{ from: 0, to: 1, start: 0, length: 1, interpolation: "linear" as const }];
+
+function clip(overrides: Partial<Clip> = {}): Clip {
+	return { asset: { type: "image", src: "https://example.com/a.jpg" }, start: 0, length: 5, ...overrides } as Clip;
+}
+
+describe("isKeyframedValue", () => {
+	it("accepts plain numbers as editable, including zero", () => {
+		expect(isKeyframedValue(0)).toBe(false);
+		expect(isKeyframedValue(0.5)).toBe(false);
+		expect(isKeyframedValue(undefined)).toBe(false);
+	});
+
+	it("rejects keyframes and unresolved merge placeholders", () => {
+		expect(isKeyframedValue(tween)).toBe(true);
+		expect(isKeyframedValue("{{ MEDIA_OPACITY }}")).toBe(true);
+	});
+});
+
+describe("hasKeyframedVisualProperty", () => {
+	it("is false for a clip whose visual properties are all fixed or absent", () => {
+		expect(hasKeyframedVisualProperty(clip())).toBe(false);
+		expect(hasKeyframedVisualProperty(clip({ opacity: 0, scale: 1 }))).toBe(false);
+	});
+
+	it.each([
+		["opacity", { opacity: tween }],
+		["scale", { scale: tween }],
+		["offset.x", { offset: { x: tween } }],
+		["offset.y", { offset: { y: tween } }],
+		["rotation", { transform: { rotate: { angle: tween } } }],
+		["skew.x", { transform: { skew: { x: tween } } }],
+		["skew.y", { transform: { skew: { y: tween } } }]
+	])("is true when %s is keyframed", (_name, overrides) => {
+		expect(hasKeyframedVisualProperty(clip(overrides as Partial<Clip>))).toBe(true);
+	});
+
+	it("ignores volume, which is asset-level and takes no part in preset composition", () => {
+		expect(hasKeyframedVisualProperty(clip({ asset: { type: "video", src: "https://example.com/a.mp4", volume: tween } } as Partial<Clip>))).toBe(
+			false
+		);
+	});
+});

--- a/tests/svg-toolbar.test.ts
+++ b/tests/svg-toolbar.test.ts
@@ -529,8 +529,10 @@ describe("SvgToolbar - Data Flow Integrity", () => {
 	it("keeps document timing intent in slider undo history", () => {
 		const mockEdit = createMockEditSession();
 		const svgClip = createSvgClip('<svg viewBox="0 0 100 100"><rect width="50" height="50"/></svg>');
+		const documentClip = { ...svgClip, start: "auto", length: "end" };
 		mockEdit.getResolvedClip.mockReturnValue(svgClip);
-		mockEdit.getDocumentClip.mockReturnValue({ ...svgClip, start: "auto", length: "end" });
+		mockEdit.getDocumentClip.mockReturnValue(documentClip);
+		mockEdit.updateClipInDocument.mockImplementation((_clipId: string, updates: object) => Object.assign(documentClip, updates));
 
 		const { toolbar, parent } = createToolbar(mockEdit);
 		// @ts-expect-error - accessing protected method for testing
@@ -544,7 +546,9 @@ describe("SvgToolbar - Data Flow Integrity", () => {
 
 		const [, initialState, finalState] = mockEdit.commitClipUpdate.mock.calls[0];
 		expect(initialState).toEqual(expect.objectContaining({ id: "clip-123", start: "auto", length: "end" }));
-		expect(finalState).toEqual(expect.objectContaining({ id: "clip-123", start: "auto", length: "end" }));
+		expect(initialState).not.toHaveProperty("opacity");
+		// Final state must carry the edit AND still be document form, not resolved.
+		expect(finalState).toEqual(expect.objectContaining({ id: "clip-123", start: "auto", length: "end", opacity: 0.5 }));
 	});
 
 	it("reads from edit session as single source of truth", () => {


### PR DESCRIPTION
Test-only follow-up to the opacity keyframe work. No source changes.

## What changed

**`tests/clip-utils.test.ts` (new)** — covers `isKeyframedValue` and `hasKeyframedVisualProperty`, which had no tests. Both are now the single source of truth for "this value is animated or bound, so a scalar write would destroy it", used by the player, the media toolbar and the canvas selection handles. Cases: `0` and `undefined` stay editable, tweens and unresolved `{{ MERGE_FIELD }}` placeholders do not, each of the seven visual properties trips the clip-level check, and a keyframed `asset.volume` deliberately does not.

**`tests/svg-toolbar.test.ts`** — repairs an assertion that could not fail. "keeps document timing intent in slider undo history" stubbed `updateClipInDocument` to a no-op while `getDocumentClip` returned the same object every call, so the committed final state was byte-identical to the initial state. It passed whether or not the slider edit reached the commit. The mock now mutates the document, and the test asserts both that the edit landed and that the state is still document form rather than resolved.

## How to verify

`npx jest tests/clip-utils.test.ts tests/svg-toolbar.test.ts` — 41 tests. Full suite: 70 suites, 1947 tests.

`test:` type, so no release is cut.
