### PR TITLE
[1/2] fix: keep a merge field's resolved text as text when it starts with digits

### DIFF
--- a/src/core/merge/merge-field-service.ts
+++ b/src/core/merge/merge-field-service.ts
@@ -91,8 +91,11 @@ export class MergeFieldService {
 	resolveToNumber(input: string): number | null {
 		if (!this.isMergeFieldTemplate(input)) return null;
 
-		const resolved = this.resolve(input);
-		const num = parseFloat(resolved);
+		// Whole-string match only: parseFloat takes a numeric prefix, so a
+		// resolved "03 image of a cat" would collapse to the number 3.
+		const resolved = this.resolve(input).trim();
+		if (resolved === "") return null;
+		const num = Number(resolved);
 		return Number.isFinite(num) ? num : null;
 	}
 

--- a/src/core/resolver.ts
+++ b/src/core/resolver.ts
@@ -81,7 +81,7 @@ function resolveMergeFieldsInClip(clip: InternalClip, mergeFields: MergeFieldSer
 			return num !== null ? num : mergeFields.resolve(value);
 		}
 		if (Array.isArray(value)) {
-			return value.map((item) => processValue(item, key));
+			return value.map(item => processValue(item, key));
 		}
 		if (value !== null && typeof value === "object") {
 			const result: Record<string, unknown> = {};

--- a/tests/merge-field-numeric-resolution.test.ts
+++ b/tests/merge-field-numeric-resolution.test.ts
@@ -1,0 +1,32 @@
+import { EventEmitter } from "../src/core/events/event-emitter";
+import { MergeFieldService } from "../src/core/merge/merge-field-service";
+
+import type { EditEventMap } from "../src/core/events/edit-events";
+
+function serviceWith(fields: Record<string, string>): MergeFieldService {
+	const service = new MergeFieldService(new EventEmitter<EditEventMap>());
+	Object.entries(fields).forEach(([name, defaultValue]) => service.register({ name, defaultValue }, { silent: true }));
+	return service;
+}
+
+describe("MergeFieldService.resolveToNumber", () => {
+	it("converts a template that resolves to a bare number", () => {
+		expect(serviceWith({ WIDTH: "1920" }).resolveToNumber("{{ WIDTH }}")).toBe(1920);
+		expect(serviceWith({ SCALE: " 2.5 " }).resolveToNumber("{{ SCALE }}")).toBe(2.5);
+	});
+
+	it("returns null when the resolved text merely starts with digits", () => {
+		const service = serviceWith({ SUBJECT: "a red apple" });
+
+		expect(service.resolveToNumber("03 image pending, merge field {{ SUBJECT }}")).toBeNull();
+		expect(service.resolveToNumber("{{ SUBJECT }} 42")).toBeNull();
+	});
+
+	it("returns null for text that resolves to an empty string", () => {
+		expect(serviceWith({ EMPTY: "" }).resolveToNumber("{{ EMPTY }}")).toBeNull();
+	});
+
+	it("returns null for a non-template input", () => {
+		expect(serviceWith({ WIDTH: "1920" }).resolveToNumber("1920")).toBeNull();
+	});
+});


### PR DESCRIPTION
A merge field whose resolved text starts with a digit became a number: `"03 image of a cat"` resolved to `3`, and the property lost its text entirely. Any value that looks numeric at the front is affected, including `"007"` and `"0xffffff"`.

`resolveToNumber` used `parseFloat`, which accepts a numeric prefix. Now a whole-string parse, so text stays text unless the entire value is a number.

This moves the SDK closer to the render backend without reaching it. The backend decides the resulting type from the type of `replace`; the SDK infers it from the property name and the resolved text, so a numeric-looking string can still differ between preview and render. Closing that gap needs a breaking change to the public merge field typings and is tracked separately.

Verify: `npx jest tests/merge-field-numeric-resolution.test.ts` — a bare number, a numeric prefix, an empty resolution, a non-template input.

Risk: a field that previously resolved to a number now stays a string unless the whole value is numeric. Templates relying on the prefix behaviour change shape.
