### PR TITLE
fix: cache-bust unsigned media URLs and warn when CORS blocks an asset

### DIFF
--- a/src/components/canvas/players/image-player.ts
+++ b/src/components/canvas/players/image-player.ts
@@ -1,4 +1,5 @@
 import type { Edit } from "@core/edit-session";
+import { toLoadUrl } from "@core/shared/utils";
 import { type Size } from "@layouts/geometry";
 import { type ResolvedClip, type ImageAsset } from "@schemas";
 import * as pixi from "pixi.js";
@@ -91,13 +92,14 @@ export class ImagePlayer extends Player {
 			throw new Error("Image asset has no src to load.");
 		}
 
-		const loadOptions: pixi.UnresolvedAsset = { src, crossorigin: "anonymous", data: {} };
-		const texture = await this.edit.assetLoader.load<pixi.Texture<pixi.ImageSource>>(src, loadOptions);
+		const loadUrl = toLoadUrl(src);
+		const loadOptions: pixi.UnresolvedAsset = { src: loadUrl, crossorigin: "anonymous", data: {} };
+		const texture = await this.edit.assetLoader.load<pixi.Texture<pixi.ImageSource>>(loadUrl, loadOptions);
 
 		if (!(texture?.source instanceof pixi.ImageSource)) {
 			if (texture) {
 				texture.destroy(true);
-				await this.edit.assetLoader.rejectAsset(src);
+				await this.edit.assetLoader.rejectAsset(loadUrl);
 			}
 			throw new Error(`Invalid image source '${src}'.`);
 		}

--- a/src/components/canvas/players/image-to-video-player.ts
+++ b/src/components/canvas/players/image-to-video-player.ts
@@ -1,5 +1,6 @@
 import type { Edit } from "@core/edit-session";
 import { computeAiAssetNumber, isAiAsset } from "@core/shared/ai-asset-utils";
+import { toLoadUrl } from "@core/shared/utils";
 import { type Size } from "@layouts/geometry";
 import { type ResolvedClip } from "@schemas";
 import * as pixi from "pixi.js";
@@ -114,13 +115,14 @@ export class ImageToVideoPlayer extends Player {
 
 	private async tryLoadTexture(src: string): Promise<boolean> {
 		try {
-			const loadOptions: pixi.UnresolvedAsset = { src, crossorigin: "anonymous", data: {} };
-			const texture = await this.edit.assetLoader.load<pixi.Texture<pixi.ImageSource>>(src, loadOptions);
+			const loadUrl = toLoadUrl(src);
+			const loadOptions: pixi.UnresolvedAsset = { src: loadUrl, crossorigin: "anonymous", data: {} };
+			const texture = await this.edit.assetLoader.load<pixi.Texture<pixi.ImageSource>>(loadUrl, loadOptions);
 
 			if (!(texture?.source instanceof pixi.ImageSource)) {
 				if (texture) {
 					texture.destroy(true);
-					await this.edit.assetLoader.rejectAsset(src);
+					await this.edit.assetLoader.rejectAsset(loadUrl);
 				}
 				return false;
 			}

--- a/src/components/canvas/players/video-player.ts
+++ b/src/components/canvas/players/video-player.ts
@@ -1,5 +1,6 @@
 import { KeyframeBuilder } from "@animations/keyframe-builder";
 import type { Edit } from "@core/edit-session";
+import { toLoadUrl } from "@core/shared/utils";
 import { type Size } from "@layouts/geometry";
 import { type ResolvedClip, type VideoAsset } from "@schemas";
 import * as pixi from "pixi.js";
@@ -178,11 +179,12 @@ export class VideoPlayer extends Player {
 			throw new Error(`Video source '${src}' is not supported. .mov files cannot be played in the browser. Please convert to .webm or .mp4 first.`);
 		}
 
-		const loadOptions: pixi.UnresolvedAsset = { src, data: { autoPlay: false, muted: false } };
+		const loadUrl = toLoadUrl(src);
+		const loadOptions: pixi.UnresolvedAsset = { src: loadUrl, data: { autoPlay: false, muted: false } };
 
 		// Use unique loader to create independent video element per player
 		// This prevents conflicts when multiple clips use the same video source
-		const texture = await this.edit.assetLoader.loadVideoUnique(src, loadOptions);
+		const texture = await this.edit.assetLoader.loadVideoUnique(loadUrl, loadOptions);
 
 		if (!texture || !(texture.source instanceof pixi.VideoSource)) {
 			throw new Error(`Invalid video source '${src}'.`);

--- a/src/components/timeline/media-thumbnail-renderer.ts
+++ b/src/components/timeline/media-thumbnail-renderer.ts
@@ -8,6 +8,7 @@
  * - Image: Loads image directly and uses original URL
  */
 
+import { toLoadUrl } from "@core/shared/utils";
 import type { ResolvedClip, ImageAsset, VideoAsset } from "@schemas";
 
 import type { ThumbnailGenerator } from "./thumbnail-generator";
@@ -196,15 +197,16 @@ export class MediaThumbnailRenderer implements ClipRenderer {
 
 	private loadImageThumbnail(src: string): Promise<{ url: string; thumbnailWidth: number } | null> {
 		return new Promise(resolve => {
+			const loadUrl = toLoadUrl(src);
 			const img = new Image();
 			img.crossOrigin = "anonymous";
 			img.onload = () => {
 				const aspectRatio = img.naturalWidth / img.naturalHeight;
 				const thumbnailWidth = Math.round(THUMBNAIL_HEIGHT * aspectRatio);
-				resolve({ url: src, thumbnailWidth });
+				resolve({ url: loadUrl, thumbnailWidth });
 			};
 			img.onerror = () => resolve(null);
-			img.src = src;
+			img.src = loadUrl;
 		});
 	}
 

--- a/src/components/timeline/thumbnail-generator.ts
+++ b/src/components/timeline/thumbnail-generator.ts
@@ -5,6 +5,8 @@
  * Designed for timeline UI, not export quality - uses smaller dimensions for performance.
  */
 
+import { toLoadUrl } from "@core/shared/utils";
+
 interface CachedThumbnail {
 	dataUrl: string;
 	thumbnailWidth: number;
@@ -181,7 +183,7 @@ export class ThumbnailGenerator {
 
 			video.addEventListener("loadeddata", onLoaded);
 			video.addEventListener("error", onError);
-			video.src = src;
+			video.src = toLoadUrl(src);
 			video.load();
 		});
 	}

--- a/src/core/edit-session.ts
+++ b/src/core/edit-session.ts
@@ -30,7 +30,7 @@ import { MergeFieldService, type SerializedMergeField } from "@core/merge";
 import { calculateSizeFromPreset, OutputSettingsManager } from "@core/output-settings-manager";
 import { SelectionManager } from "@core/selection-manager";
 import { findEligibleSourceClips, ensureClipAlias } from "@core/shared/source-clip-finder";
-import { deepMerge, nextFrame, setNestedValue } from "@core/shared/utils";
+import { deepMerge, nextFrame, setNestedValue, toLoadUrl } from "@core/shared/utils";
 import { calculateTimelineEnd, resolveAutoLength, resolveAutoStart } from "@core/timing/resolver";
 import { type Milliseconds, type ResolutionContext, type Seconds, sec, isAliasReference } from "@core/timing/types";
 import { TimingManager } from "@core/timing-manager";
@@ -1857,9 +1857,11 @@ export class Edit {
 	private unloadClipAssets(clip: Player): void {
 		const { asset } = clip.clipConfiguration;
 		if (asset && "src" in asset && typeof asset.src === "string") {
-			const safeToUnload = this.assetLoader.decrementRef(asset.src);
-			if (safeToUnload && pixi.Assets.cache.has(asset.src)) {
-				pixi.Assets.unload(asset.src);
+			// Visual players load under the cache-busted URL; other assets under the raw src
+			const key = ["image", "video", "image-to-video"].includes(asset.type) ? toLoadUrl(asset.src) : asset.src;
+			const safeToUnload = this.assetLoader.decrementRef(key);
+			if (safeToUnload && pixi.Assets.cache.has(key)) {
+				pixi.Assets.unload(key);
 			}
 		}
 	}

--- a/src/core/loaders/asset-loader.ts
+++ b/src/core/loaders/asset-loader.ts
@@ -1,3 +1,4 @@
+import { warnIfCorsBlocked } from "@core/shared/utils";
 import * as pixi from "pixi.js";
 
 import { AssetLoadTracker, type AssetLoadInfoStatus } from "../events/asset-load-tracker";
@@ -62,8 +63,8 @@ export class AssetLoader {
 			const resolvedAsset = useSafari
 				? await this.loadVideoForSafari<TResolvedAsset>(identifier, loadOptions)
 				: await pixi.Assets.load<TResolvedAsset>(loadOptions, progress => {
-					this.updateAssetLoadMetadata(identifier, "loading", progress);
-				});
+						this.updateAssetLoadMetadata(identifier, "loading", progress);
+					});
 
 			if (resolvedAsset == null) {
 				console.warn(`[AssetLoader.load] Empty asset returned for "${identifier}"`);
@@ -76,6 +77,7 @@ export class AssetLoader {
 			return resolvedAsset;
 		} catch (error) {
 			console.warn(`[AssetLoader.load] Failed to load "${identifier}":`, error);
+			warnIfCorsBlocked(identifier).catch(() => {});
 			this.updateAssetLoadMetadata(identifier, "failed", 1);
 			await this.cleanupFailedLoad(identifier);
 			return null;
@@ -132,6 +134,7 @@ export class AssetLoader {
 			this.updateAssetLoadMetadata(identifier, "success", 1);
 			return texture;
 		} catch (_error) {
+			warnIfCorsBlocked(identifier).catch(() => {});
 			this.updateAssetLoadMetadata(identifier, "failed", 1);
 			return null;
 		}

--- a/src/core/shared/utils.ts
+++ b/src/core/shared/utils.ts
@@ -191,3 +191,39 @@ export async function validateAssetUrl(url: string): Promise<UrlValidationResult
 		return { valid: false, error: message };
 	}
 }
+
+/**
+ * Cache-busting URL for loading media cross-origin. A response cached from a
+ * non-CORS fetch (e.g. the same URL in a plain <img> on the host page) is
+ * served without CORS headers and fails crossorigin loads; a query parameter
+ * forces a fresh fetch. URLs that already carry a query string pass through
+ * untouched — signed URLs break if any parameter is added.
+ * @internal
+ */
+export function toLoadUrl(src: string): string {
+	if (!src.startsWith("http") || src.includes("?")) return src;
+	return `${src}?x-cors=1`;
+}
+
+/**
+ * After a media load failure, detect whether the URL is reachable but blocked
+ * by missing CORS headers, and warn with the fix. Distinguishes a CORS
+ * misconfiguration (fixable on the asset host) from a dead URL.
+ * @internal
+ */
+export async function warnIfCorsBlocked(url: string): Promise<void> {
+	if (!url.startsWith("http")) return;
+	try {
+		await fetch(url, { method: "HEAD", mode: "cors" });
+	} catch {
+		try {
+			await fetch(url, { method: "HEAD", mode: "no-cors" });
+			console.warn(
+				`[AssetLoader] "${url}" is reachable but its server does not send CORS headers, so the browser blocks it. ` +
+					`Add a CORS rule to the bucket/CDN allowing this origin, or ingest the file with the Shotstack Ingest API.`
+			);
+		} catch {
+			// Unreachable (network/DNS) — the load failure itself is the whole story
+		}
+	}
+}

--- a/src/core/timing/resolver.ts
+++ b/src/core/timing/resolver.ts
@@ -4,6 +4,7 @@
  */
 
 import type { Player } from "@canvas/players/player";
+import { toLoadUrl } from "@core/shared/utils";
 import type { Asset } from "@schemas";
 
 import { type ResolutionContext, type ResolvedTiming, type Seconds, type TimingIntent, isAliasReference, sec } from "./types";
@@ -50,7 +51,7 @@ export function probeMediaDuration(src: string): Promise<number | null> {
 		video.crossOrigin = "anonymous";
 		video.onloadedmetadata = (): void => resolve(video.duration);
 		video.onerror = (): void => resolve(null);
-		video.src = src;
+		video.src = toLoadUrl(src);
 	});
 }
 

--- a/tests/media-load-url.test.ts
+++ b/tests/media-load-url.test.ts
@@ -1,0 +1,68 @@
+import { toLoadUrl, warnIfCorsBlocked } from "@core/shared/utils";
+
+describe("toLoadUrl", () => {
+	it("appends the cache-busting parameter to plain http(s) URLs", () => {
+		expect(toLoadUrl("https://bucket.s3.amazonaws.com/video.mp4")).toBe("https://bucket.s3.amazonaws.com/video.mp4?x-cors=1");
+		expect(toLoadUrl("http://example.com/image.png")).toBe("http://example.com/image.png?x-cors=1");
+	});
+
+	it("leaves URLs with a query string untouched", () => {
+		const signed = "https://bucket.s3.amazonaws.com/video.mp4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Signature=abc";
+		expect(toLoadUrl(signed)).toBe(signed);
+		expect(toLoadUrl("https://cdn.example.com/a.jpg?v=2")).toBe("https://cdn.example.com/a.jpg?v=2");
+	});
+
+	it("leaves non-http URLs untouched", () => {
+		const dataUri = "data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg'/>";
+		expect(toLoadUrl(dataUri)).toBe(dataUri);
+		expect(toLoadUrl("blob:https://example.com/uuid")).toBe("blob:https://example.com/uuid");
+	});
+});
+
+describe("warnIfCorsBlocked", () => {
+	let warnSpy: jest.SpyInstance;
+	let fetchMock: jest.Mock;
+
+	beforeEach(() => {
+		warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+		fetchMock = jest.fn();
+		global.fetch = fetchMock as never;
+	});
+
+	afterEach(() => {
+		warnSpy.mockRestore();
+	});
+
+	it("warns when the URL is reachable but blocks CORS", async () => {
+		fetchMock.mockRejectedValueOnce(new TypeError("Failed to fetch")).mockResolvedValueOnce({ type: "opaque" });
+
+		await warnIfCorsBlocked("https://bucket.s3.amazonaws.com/video.mp4");
+
+		expect(fetchMock).toHaveBeenNthCalledWith(1, "https://bucket.s3.amazonaws.com/video.mp4", { method: "HEAD", mode: "cors" });
+		expect(fetchMock).toHaveBeenNthCalledWith(2, "https://bucket.s3.amazonaws.com/video.mp4", { method: "HEAD", mode: "no-cors" });
+		expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("CORS"));
+	});
+
+	it("stays silent when the CORS request succeeds", async () => {
+		fetchMock.mockResolvedValueOnce({ ok: true });
+
+		await warnIfCorsBlocked("https://example.com/a.jpg");
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it("stays silent when the URL is unreachable", async () => {
+		fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
+
+		await warnIfCorsBlocked("https://nowhere.invalid/a.jpg");
+
+		expect(warnSpy).not.toHaveBeenCalled();
+	});
+
+	it("skips non-http URLs", async () => {
+		await warnIfCorsBlocked("data:image/png;base64,abc");
+
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});

--- a/tests/media-player-fallback.test.ts
+++ b/tests/media-player-fallback.test.ts
@@ -314,4 +314,27 @@ describe("media player source URLs", () => {
 
 		expect(edit.assetLoader.load).toHaveBeenCalledWith(signedSrc, { src: signedSrc, crossorigin: "anonymous", data: {} });
 	});
+
+	// Query-less URLs get a cache-busting parameter so a response cached
+	// without CORS headers (plain <img> on the host page) is never reused
+	const plainSrc = "https://bucket.s3.amazonaws.com/media.mp4";
+	const bustedSrc = `${plainSrc}?x-cors=1`;
+
+	it("cache-busts a query-less image src", async () => {
+		const edit = createEdit();
+		edit.assetLoader.load.mockResolvedValueOnce(null);
+
+		await new ImagePlayer(edit as never, { asset: { type: "image", src: plainSrc }, start: 0, length: 5 } as ResolvedClip).load();
+
+		expect(edit.assetLoader.load).toHaveBeenCalledWith(bustedSrc, { src: bustedSrc, crossorigin: "anonymous", data: {} });
+	});
+
+	it("cache-busts a query-less video src", async () => {
+		const edit = createEdit();
+		edit.assetLoader.loadVideoUnique.mockResolvedValueOnce(null);
+
+		await new VideoPlayer(edit as never, { asset: { type: "video", src: plainSrc }, start: 0, length: 5 } as ResolvedClip).load();
+
+		expect(edit.assetLoader.loadVideoUnique).toHaveBeenCalledWith(bustedSrc, { src: bustedSrc, data: { autoPlay: false, muted: false } });
+	});
 });


### PR DESCRIPTION
Customer media fails two ways.

First: a poisoned cache. The host page shows the URL in a plain `<img>`. The browser caches that response without CORS headers. The editor's crossorigin load reuses it and fails. Raw S3 omits `Vary: Origin` on non-CORS responses. Bucket config cannot prevent this.

The fix appends `x-cors=1` to URLs without a query string. Any query string may be a signature. An added parameter 403s signed URLs. That was the bug #154 fixed. Players, thumbnails, the duration probe and unload share the busted URL. One cache entry per asset. Load and unload keys match.

Second: no CORS rule on the host. No client-side fix exists. A failed load now probes the URL. Reachable but header-less → console warning names the missing rule.

Verify: `npx jest tests/media-load-url.test.ts tests/media-player-fallback.test.ts`