### PR TITLE
chore(deps): bump @shotstack/schemas to 1.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
 		"vite-plugin-dts": "^4.5.4"
 	},
 	"dependencies": {
-		"@shotstack/schemas": "1.14.1",
+		"@shotstack/schemas": "1.18.0",
 		"@shotstack/shotstack-canvas": "^2.10.2",
 		"howler": "^2.2.4",
 		"mediabunny": "^1.11.2",

--- a/tests/schema.test.ts
+++ b/tests/schema.test.ts
@@ -400,9 +400,14 @@ describe("API-accepted templates parse at load", () => {
 		expect(result.success).toBe(true);
 	});
 
-	it("accepts prompt-driven audio assets with voice and newscaster", () => {
+	it("accepts prompt-driven audio assets with model-scoped options", () => {
 		const result = ClipSchema.safeParse({
-			asset: { type: "audio", prompt: "Read the news intro", voice: "Joanna", newscaster: true },
+			asset: {
+				type: "audio",
+				prompt: "Read the news intro",
+				model: "polly-neural",
+				options: { voice: "Joanna", newscaster: true }
+			},
 			start: 0,
 			length: 5
 		});


### PR DESCRIPTION
The current schemas dependency predates model-scoped generation options and rejects API-valid assets.

The audio fixture moves voice and newscaster under the `polly-neural` model’s `options`; this is required by 1.18.0 and keeps the dependency bump green.

Verify: `npm run verify:ci`

Risk: Schema validation becomes stricter for outdated root-level generation options. Revert this PR to restore 1.14.1.