### PR TITLE
chore: raise the umd bundle size ceiling to 3.25 mb

### DIFF
--- a/test-package.js
+++ b/test-package.js
@@ -134,7 +134,7 @@ const CONTRACT = {
 		{ className: "Timeline", tokens: ["load(): Promise<void>;"] }
 	],
 	bundleSizeLimits: {
-		"dist/shotstack-studio.umd.js": 3 * 1024 * 1024,
+		"dist/shotstack-studio.umd.js": 3.25 * 1024 * 1024,
 		"dist/shotstack-studio.es.js": 4 * 1024 * 1024,
 		"dist/internal.umd.js": 2.5 * 1024 * 1024,
 		"dist/internal.es.js": 3 * 1024 * 1024


### PR DESCRIPTION
The UMD ceiling was set at exactly 3 MB and `main` ships at 2.9973 MB — 2.8 KB of headroom. Any feature of any size trips it, so the check now fires on arrival rather than on a regression, which is not what a size ratchet is for.

3.25 MB restores its purpose: catch a jump, ignore a creep. The other three bundles keep their existing limits and still have room (ES 3.71/4.0, internal UMD 2.11/2.5, internal ES 2.52/3.0).

Verify: `npm run test:package`

Risk: a genuine size regression up to 250 KB would now pass unflagged. Accepted — the alternative is a check that blocks every merge.
