### PR TITLE
refactor: lift generation type and prompt helpers into shared utils

### DIFF
--- a/src/core/shared/ai-asset-utils.ts
+++ b/src/core/shared/ai-asset-utils.ts
@@ -212,3 +212,16 @@ export function truncatePrompt(prompt: string, maxLength = 60): string {
 	}
 	return `${prompt.substring(0, maxLength - 3)}...`;
 }
+
+/** Asset type → the media kind a generator produces. Folds the legacy aliases onto the unified types. */
+export const GENERATION_TYPE: Readonly<Record<string, "image" | "video" | "audio">> = {
+	image: "image",
+	video: "video",
+	audio: "audio",
+	"text-to-image": "image",
+	"image-to-video": "video",
+	"text-to-speech": "audio"
+};
+
+/** The legacy speech asset keeps its prompt under `text`. */
+export const promptProperty = (asset: { type: string }): "prompt" | "text" => (asset.type === "text-to-speech" ? "text" : "prompt");

--- a/src/core/ui/generate-toolbar.ts
+++ b/src/core/ui/generate-toolbar.ts
@@ -3,33 +3,22 @@ import {
 	isGenerationOptionValueValid,
 	missingGenerationOptions,
 	reconcileGenerationOptions,
-	type GenerationAssetType,
 	type GenerationModelDefinition,
 	type GenerationOptionDefinition
 } from "@core/generation/model-catalogue";
 import { MERGE_FIELD_TEST_PATTERN } from "@core/merge/merge-field-service";
-import { canCarryPrompt } from "@core/shared/ai-asset-utils";
+import { canCarryPrompt, GENERATION_TYPE, promptProperty } from "@core/shared/ai-asset-utils";
 import { injectShotstackStyles } from "@styles/inject";
 
 import { BaseToolbar, TOOLBAR_ICONS } from "./base-toolbar";
 
 const PROMPT_DEBOUNCE_MS = 300;
-const GENERATION_TYPE: Readonly<Record<string, GenerationAssetType>> = {
-	image: "image",
-	video: "video",
-	audio: "audio",
-	"text-to-image": "image",
-	"image-to-video": "video",
-	"text-to-speech": "audio"
-};
-
 const OPTION_INPUT_TYPE: Readonly<Record<GenerationOptionDefinition["type"], string>> = {
 	boolean: "checkbox",
 	integer: "number",
 	string: "text"
 };
 
-const promptProperty = (asset: { type: string }): "prompt" | "text" => (asset.type === "text-to-speech" ? "text" : "prompt");
 const record = (value: unknown): Record<string, unknown> =>
 	typeof value === "object" && value !== null && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
 


### PR DESCRIPTION
`GENERATION_TYPE` and `promptProperty` describe how an asset type maps to a generated media kind and where a legacy speech asset keeps its prompt. Both are facts about assets, not about a toolbar, and both are needed outside the toolbar.

Pure move: the two declarations are unchanged, the toolbar imports them from their new home, and its now-unused type import goes with them. No behaviour change.

Verify: `npm run verify:ci` — the existing suite passes unmodified, which is the proof that nothing moved but the code.
