### PR TITLE
[2/2] feat: let a host annotate the generate action

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -189,6 +189,7 @@ Available event names:
 | Duration | `duration:changed` |
 | Output | `output:resized`, `output:resolutionChanged`, `output:aspectRatioChanged`, `output:fpsChanged`, `output:formatChanged`, `output:destinationsChanged` |
 | Merge fields | `mergefield:changed` |
+| Generation | `generation:configChanged` |
 
 ### Generating assets from prompts
 
@@ -208,6 +209,13 @@ controls. Entries must include their option schema; those without one are ignore
 [Edit API](https://shotstack.io/docs/api/#shotstack-edit) returns this shape from
 `GET /models?expand=options`. The SDK stores a snapshot; fetching and refreshing it remain
 the host's responsibility.
+
+Whenever the selected clip's model, options, length or prompt changes, the editor emits
+`generation:configChanged` with what it knows: `clipId`, `type`, `model`, `options`, the
+resolved `length` in seconds (`undefined` for `auto`), and the resolved `prompt`. Reply with
+`edit.setGenerationStatus(clipId, { text, tone })` to show a line beside Generate; a `tone`
+of `error` also disables it. Pass `undefined` to clear. Clearing the prompt or deleting the
+clip emits nothing, so also clear any held state on `clip:selected` or `edit:changed`.
 
 The SDK writes the returned URL to the clip, so the change is undoable and autosaves
 like any other edit. It tracks whether a clip is generating or has failed, and renders

--- a/src/core/edit-session.ts
+++ b/src/core/edit-session.ts
@@ -22,13 +22,21 @@ import { SetUpdatedClipCommand } from "@core/commands/set-updated-clip-command";
 import { type TimingUpdateParams, UpdateClipTimingCommand } from "@core/commands/update-clip-timing-command";
 import { UpdateTextContentCommand } from "@core/commands/update-text-content-command";
 import type { MergeFieldBinding } from "@core/edit-document";
-import { EditEvent, InternalEvent, type EditEventMap, type InternalEventMap } from "@core/events/edit-events";
+import {
+	EditEvent,
+	InternalEvent,
+	type EditEventMap,
+	type InternalEventMap,
+	type GenerationConfig,
+	type GenerationStatus
+} from "@core/events/edit-events";
 import { EventEmitter, type ReadonlyEventEmitter } from "@core/events/event-emitter";
 import { parseFontFamily } from "@core/fonts/font-config";
 import { LumaMaskController } from "@core/luma-mask-controller";
 import { MergeFieldService, type SerializedMergeField } from "@core/merge";
 import { calculateSizeFromPreset, OutputSettingsManager } from "@core/output-settings-manager";
 import { SelectionManager } from "@core/selection-manager";
+import { GENERATION_TYPE, isAiAsset, promptProperty } from "@core/shared/ai-asset-utils";
 import { findEligibleSourceClips, ensureClipAlias } from "@core/shared/source-clip-finder";
 import { deepMerge, nextFrame, setNestedValue, toLoadUrl } from "@core/shared/utils";
 import { calculateTimelineEnd, resolveAutoLength, resolveAutoStart } from "@core/timing/resolver";
@@ -124,6 +132,8 @@ export class Edit {
 	// ─── Internal Bookkeeping ─────────────────────────────────────────────────
 	private clipsToDispose = new Set<Player>();
 	private clipErrors = new Map<string, { error: string; assetType: string }>();
+	private generationStatuses = new Map<string, GenerationStatus>();
+	private lastGenerationConfigKey: string | null = null;
 	private playerByClipId = new Map<string, Player>();
 	private lumaContentRelations = new Map<string, string>();
 	private fontMetadata = new Map<string, { baseFamilyName: string; weight: number }>();
@@ -139,6 +149,36 @@ export class Edit {
 		const live = new Set<string>();
 		for (const track of edit.timeline.tracks) for (const clip of track.clips) live.add(clip.id);
 		this.assetGenerator.abortMissing(live);
+	};
+
+	// Clearing the key on deselection lets a re-selected clip announce itself again.
+	private emitGenerationConfig = (): void => {
+		const clipId = this.getSelectedClipInfo()?.player.clipId ?? null;
+		const resolved = clipId ? this.getResolvedClipById(clipId) : null;
+		const raw = clipId ? this.getDocumentClipById(clipId) : null;
+		if (!clipId || !resolved || !raw || !isAiAsset(resolved.asset)) {
+			this.lastGenerationConfigKey = null;
+			return;
+		}
+
+		const asset = resolved.asset as unknown as Record<string, unknown>;
+		const type = GENERATION_TYPE[String(asset["type"])];
+		const promptValue = asset[promptProperty(resolved.asset)];
+		const { options } = asset;
+		const config: GenerationConfig = {
+			clipId,
+			type,
+			...(typeof asset["model"] === "string" ? { model: asset["model"] } : {}),
+			options: typeof options === "object" && options !== null && !Array.isArray(options) ? (options as Record<string, unknown>) : {},
+			// The resolver fabricates a placeholder for "auto", so only the raw clip can say the length is unknown.
+			length: raw.length === "auto" ? undefined : resolved.length,
+			prompt: typeof promptValue === "string" ? promptValue : ""
+		};
+
+		const key = JSON.stringify(config);
+		if (key === this.lastGenerationConfigKey) return;
+		this.lastGenerationConfigKey = key;
+		this.internalEvents.emit(EditEvent.GenerationConfigChanged, config);
 	};
 
 	/**
@@ -291,7 +331,9 @@ export class Edit {
 	public dispose(): void {
 		this.clearClips();
 		this.internalEvents.off(InternalEvent.Resolved, this.onResolvedForGeneration);
+		for (const name of Edit.GenerationConfigTriggers) this.internalEvents.off(name, this.emitGenerationConfig);
 		this.assetGenerator.abortAll();
+		this.generationStatuses.clear();
 		this.lumaMaskController.dispose();
 		this.playerReconciler.dispose();
 
@@ -450,6 +492,17 @@ export class Edit {
 	public registerAssetGenerator(handler: AssetGeneratorHandler, options?: AssetGeneratorOptions): void {
 		this.assetGenerator.register(handler, options);
 		this.internalEvents.emit(InternalEvent.AssetGeneratorChanged);
+	}
+
+	public setGenerationStatus(clipId: string, status: GenerationStatus | undefined): void {
+		if (status === undefined) this.generationStatuses.delete(clipId);
+		else this.generationStatuses.set(clipId, status);
+		this.internalEvents.emit(InternalEvent.GenerationStatusChanged, { clipId });
+	}
+
+	/** @internal */
+	public getGenerationStatus(clipId: string): GenerationStatus | undefined {
+		return this.generationStatuses.get(clipId);
 	}
 
 	/** @internal */
@@ -2678,8 +2731,17 @@ export class Edit {
 
 	// ─── Event Listeners ─────────────────────────────────────────────────────────
 
+	private static readonly GenerationConfigTriggers = [
+		EditEvent.ClipSelected,
+		EditEvent.SelectionCleared,
+		EditEvent.EditChanged,
+		EditEvent.MergeFieldChanged,
+		EditEvent.TimelineUpdated
+	] as const;
+
 	private setupGenerationListeners(): void {
 		this.internalEvents.on(InternalEvent.Resolved, this.onResolvedForGeneration);
+		for (const name of Edit.GenerationConfigTriggers) this.internalEvents.on(name, this.emitGenerationConfig);
 	}
 
 	private setupIntentListeners(): void {

--- a/src/core/events/edit-events.ts
+++ b/src/core/events/edit-events.ts
@@ -98,6 +98,9 @@ export const EditEvent = {
 	// Merge fields
 	MergeFieldChanged: "mergefield:changed",
 
+	// Generation
+	GenerationConfigChanged: "generation:configChanged",
+
 	// Timeline UI
 	TimelineResized: "timeline:resized"
 } as const;
@@ -138,8 +141,23 @@ export const InternalEvent = {
 	AssetGeneratorChanged: "assetGenerator:changed",
 	ClipGenerationStarted: "clip:generationStarted",
 	ClipGenerationCompleted: "clip:generationCompleted",
-	ClipGenerationFailed: "clip:generationFailed"
+	ClipGenerationFailed: "clip:generationFailed",
+	GenerationStatusChanged: "generation:statusChanged"
 } as const;
+
+export type GenerationConfig = {
+	clipId: string;
+	type: "image" | "video" | "audio";
+	model?: string;
+	options: Record<string, unknown>;
+	length: number | undefined;
+	prompt: string;
+};
+
+export type GenerationStatus = {
+	text: string;
+	tone?: "neutral" | "warning" | "error";
+};
 
 // ─────────────────────────────────────────────────────────────
 // Event Payload Maps
@@ -194,6 +212,9 @@ export type EditEventMap = {
 	// Merge fields
 	[EditEvent.MergeFieldChanged]: { fields: MergeField[] };
 
+	// Generation
+	[EditEvent.GenerationConfigChanged]: GenerationConfig;
+
 	// Timeline UI
 	[EditEvent.TimelineResized]: { height: number };
 };
@@ -237,4 +258,5 @@ export type InternalEventMap = {
 	[InternalEvent.ClipGenerationStarted]: { clipId: string };
 	[InternalEvent.ClipGenerationCompleted]: { clipId: string };
 	[InternalEvent.ClipGenerationFailed]: { clipId: string; error: string };
+	[InternalEvent.GenerationStatusChanged]: { clipId: string };
 };

--- a/src/core/ui/generate-toolbar.ts
+++ b/src/core/ui/generate-toolbar.ts
@@ -13,6 +13,7 @@ import { injectShotstackStyles } from "@styles/inject";
 import { BaseToolbar, TOOLBAR_ICONS } from "./base-toolbar";
 
 const PROMPT_DEBOUNCE_MS = 300;
+
 const OPTION_INPUT_TYPE: Readonly<Record<GenerationOptionDefinition["type"], string>> = {
 	boolean: "checkbox",
 	integer: "number",
@@ -94,9 +95,7 @@ export class GenerateToolbar extends BaseToolbar {
 			<button class="ss-media-toolbar-btn ss-ai-generate-btn" data-action="generate">
 				<span data-generate-label>Generate</span>
 			</button>
-			<span class="ss-ai-note" data-generate-note hidden
-				title="Rendering generates this from the prompt. Register an asset generator to preview it here."
-				>Generates on render</span>
+			<span class="ss-ai-note" data-generate-note hidden>Generates on render</span>
 			<span class="ss-ai-error" data-generate-error hidden></span>
 		`;
 
@@ -182,7 +181,12 @@ export class GenerateToolbar extends BaseToolbar {
 		// mount() can run more than once on an instance; never stack listeners.
 		if (this.generationUnsubscribers.length > 0) return;
 		const events = this.edit.getInternalEvents();
-		const names = [InternalEvent.ClipGenerationStarted, InternalEvent.ClipGenerationCompleted, InternalEvent.ClipGenerationFailed] as const;
+		const names = [
+			InternalEvent.ClipGenerationStarted,
+			InternalEvent.ClipGenerationCompleted,
+			InternalEvent.ClipGenerationFailed,
+			InternalEvent.GenerationStatusChanged
+		] as const;
 		for (const name of names) {
 			const handler = (payload: { clipId: string }): void => {
 				if (payload.clipId === this.getSelectedClipId()) this.syncState();
@@ -385,7 +389,25 @@ export class GenerateToolbar extends BaseToolbar {
 		const missing = this.syncCatalogueControls(record(asset));
 		const hasGenerator = this.edit.hasAssetGenerator();
 		this.generateBtn.hidden = !hasGenerator;
-		if (this.generateNote) this.generateNote.hidden = hasGenerator;
+		const status = hasGenerator ? this.edit.getGenerationStatus(this.getSelectedClipId() ?? "") : undefined;
+		if (this.generateNote) {
+			if (!hasGenerator) {
+				this.generateNote.textContent = "Generates on render";
+				this.generateNote.title = "Rendering generates this from the prompt. Register an asset generator to preview it here.";
+				delete this.generateNote.dataset["tone"];
+				this.generateNote.hidden = false;
+			} else if (status) {
+				this.generateNote.textContent = status.text;
+				this.generateNote.dataset["tone"] = status.tone ?? "neutral";
+				this.generateNote.removeAttribute("title");
+				this.generateNote.hidden = false;
+			} else {
+				this.generateNote.textContent = "";
+				delete this.generateNote.dataset["tone"];
+				this.generateNote.removeAttribute("title");
+				this.generateNote.hidden = true;
+			}
+		}
 		if (!hasGenerator) {
 			if (this.generateError) this.generateError.hidden = true;
 			return;
@@ -396,7 +418,8 @@ export class GenerateToolbar extends BaseToolbar {
 		const generating = state?.status === "generating";
 		const hasPrompt = (this.promptInput?.value ?? "").trim() !== "";
 		const label = this.generateBtn.querySelector("[data-generate-label]");
-		this.generateBtn.disabled = generating || !hasPrompt || missing.length > 0;
+		const blocked = status?.tone === "error";
+		this.generateBtn.disabled = generating || !hasPrompt || missing.length > 0 || blocked;
 		this.generateBtn.classList.toggle("is-generating", generating);
 		if (label) {
 			if (generating) label.textContent = "Generating…";

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,5 +12,6 @@ export type { UIControllerOptions, ToolbarButtonConfig } from "@core/ui/ui-contr
 export type { AssetGenerationRequest, AssetGeneratorHandler, AssetGeneratorOptions } from "@core/generation/asset-generator";
 export type { EditConfig } from "@core/schemas";
 export type { CommandResult } from "@core/commands/types";
+export type { GenerationConfig, GenerationStatus } from "@core/events/edit-events";
 
 export const VERSION = pkg.version;

--- a/src/styles/ui/generate-toolbar.css
+++ b/src/styles/ui/generate-toolbar.css
@@ -88,6 +88,14 @@
 	display: none;
 }
 
+.ss-ai-note[data-tone="warning"] {
+	color: #fcd34d;
+}
+
+.ss-ai-note[data-tone="error"] {
+	color: #fca5a5;
+}
+
 .ss-ai-error {
 	max-width: 180px;
 	padding: 0 2px;

--- a/test-package.js
+++ b/test-package.js
@@ -60,7 +60,7 @@ const CONTRACT = {
 			"clearSelection(",
 			"registerClipRenderer("
 		],
-		Edit: ["validateEdit(", "getTimelineFonts(", "getContentClipIdForLuma(", "getInternalEvents(", "getGenerationModels(", "pruneUnusedFonts("]
+		Edit: ["validateEdit(", "getTimelineFonts(", "getContentClipIdForLuma(", "getInternalEvents(", "getGenerationModels(", "pruneUnusedFonts(", "getGenerationStatus("]
 	},
 	dtsForbiddenTokens: [
 		"export declare class SelectionHandles",
@@ -128,7 +128,14 @@ const CONTRACT = {
 		"export declare type Seconds ="
 	],
 	dtsPublicAnchors: [
-		{ className: "Edit", tokens: ["load(): Promise<void>;", "registerAssetGenerator(handler: AssetGeneratorHandler, options?: AssetGeneratorOptions): void;"] },
+		{
+			className: "Edit",
+			tokens: [
+				"load(): Promise<void>;",
+				"registerAssetGenerator(handler: AssetGeneratorHandler, options?: AssetGeneratorOptions): void;",
+				"setGenerationStatus(clipId: string, status: GenerationStatus | undefined): void;"
+			]
+		},
 		{ className: "Canvas", tokens: ["load(): Promise<void>;"] },
 		{ className: "UIController", tokens: ["registerButton(config: ToolbarButtonConfig): this;"] },
 		{ className: "Timeline", tokens: ["load(): Promise<void>;"] }

--- a/tests/edit-clip-operations.test.ts
+++ b/tests/edit-clip-operations.test.ts
@@ -6,7 +6,8 @@
  */
 
 import { Edit } from "@core/edit-session";
-import { InternalEvent } from "@core/events/edit-events";
+import { ShotstackEdit } from "@core/shotstack-edit";
+import { EditEvent, InternalEvent } from "@core/events/edit-events";
 import { PlayerType } from "@canvas/players/player";
 import type { EventEmitter } from "@core/events/event-emitter";
 import type { Clip, ResolvedClip } from "@schemas";
@@ -1779,6 +1780,145 @@ describe("Edit Clip Operations", () => {
 			expect(edit.getClip(0, 1)?.asset?.type).toBe("video");
 			// Text clip shifted from index 3 to index 2
 			expect(edit.getClip(0, 2)?.asset?.type).toBe("text");
+		});
+	});
+
+	describe("generation status", () => {
+		it("stores a status per clip and announces the change", () => {
+			edit.setGenerationStatus("clip-a", { text: "host line", tone: "neutral" });
+			expect(edit.getGenerationStatus("clip-a")).toEqual({ text: "host line", tone: "neutral" });
+			expect(emitSpy).toHaveBeenCalledWith(InternalEvent.GenerationStatusChanged, { clipId: "clip-a" });
+		});
+
+		it("clears a status with undefined", () => {
+			edit.setGenerationStatus("clip-a", { text: "x" });
+			edit.setGenerationStatus("clip-a", undefined);
+			expect(edit.getGenerationStatus("clip-a")).toBeUndefined();
+			expect(emitSpy).toHaveBeenLastCalledWith(InternalEvent.GenerationStatusChanged, { clipId: "clip-a" });
+		});
+
+		it("keeps statuses for different clips apart", () => {
+			edit.setGenerationStatus("clip-a", { text: "a" });
+			edit.setGenerationStatus("clip-b", { text: "b", tone: "error" });
+			expect(edit.getGenerationStatus("clip-a")).toEqual({ text: "a" });
+			expect(edit.getGenerationStatus("clip-b")).toEqual({ text: "b", tone: "error" });
+		});
+
+		it("drops stored statuses on dispose", () => {
+			edit.setGenerationStatus("clip-a", { text: "a" });
+			edit.dispose();
+			expect(edit.getGenerationStatus("clip-a")).toBeUndefined();
+		});
+	});
+
+	describe("generation:configChanged", () => {
+		const configs = (spy: jest.SpyInstance) =>
+			spy.mock.calls.filter(([name]) => name === EditEvent.GenerationConfigChanged).map(([, payload]) => payload);
+
+		const promptEdit = async (clip: Record<string, unknown>, merge: { find: string; replace: string }[] = []) => {
+			const e = new Edit({
+				timeline: { tracks: [{ clips: [{ start: 0, length: 4, ...clip }] }] },
+				...(merge.length ? { merge } : {}),
+				output: { size: { width: 1920, height: 1080 }, format: "mp4" }
+			} as never);
+			await e.load();
+			const spy = jest.spyOn(e.getInternalEvents(), "emit");
+			return { e, spy };
+		};
+
+		it("emits the selected clip's configuration on selection", async () => {
+			const { e, spy } = await promptEdit({
+				asset: { type: "audio", prompt: "hello", model: "polly-neural", options: { voice: "Matthew" } }
+			});
+			e.selectClip(0, 0);
+			expect(configs(spy)).toEqual([
+				{ clipId: e.getClipId(0, 0), type: "audio", model: "polly-neural", options: { voice: "Matthew" }, length: 4, prompt: "hello" }
+			]);
+		});
+
+		it("resolves merge fields in the prompt", async () => {
+			const { e, spy } = await promptEdit({ asset: { type: "image", prompt: "a {{ THING }}" } }, [{ find: "THING", replace: "cat" }]);
+			e.selectClip(0, 0);
+			expect(configs(spy)[0]).toMatchObject({ prompt: "a cat" });
+		});
+
+		it("reads a text-to-speech prompt from the text field and reports audio", async () => {
+			const { e, spy } = await promptEdit({ asset: { type: "text-to-speech", text: "say this", voice: "Matthew" } });
+			e.selectClip(0, 0);
+			expect(configs(spy)[0]).toMatchObject({ type: "audio", prompt: "say this" });
+		});
+
+		it("omits model when the clip has none and reports empty options", async () => {
+			const { e, spy } = await promptEdit({ asset: { type: "image", prompt: "a cat" } });
+			e.selectClip(0, 0);
+			const [payload] = configs(spy);
+			expect(payload).not.toHaveProperty("model");
+			expect(payload.options).toEqual({});
+		});
+
+		it("reports undefined length for auto", async () => {
+			const { e, spy } = await promptEdit({ asset: { type: "video", prompt: "pan" }, length: "auto" });
+			e.selectClip(0, 0);
+			expect(configs(spy)[0]).toHaveProperty("length", undefined);
+		});
+
+		it("reports resolved seconds for end", async () => {
+			const e = new Edit({
+				timeline: {
+					tracks: [
+						{ clips: [{ asset: { type: "video", prompt: "pan" }, start: 2, length: "end" }] },
+						{ clips: [{ asset: { type: "image", src: "https://cdn/x.png" }, start: 0, length: 10 }] }
+					]
+				},
+				output: { size: { width: 1920, height: 1080 }, format: "mp4" }
+			} as never);
+			await e.load();
+			const spy = jest.spyOn(e.getInternalEvents(), "emit");
+			e.selectClip(0, 0);
+			expect(configs(spy)[0].length).toBe(8);
+		});
+
+		it("re-emits when the selected clip's option changes and not otherwise", async () => {
+			const { e, spy } = await promptEdit({ asset: { type: "image", prompt: "a cat", model: "m", options: { resolution: "1K" } } });
+			e.selectClip(0, 0);
+			await e.updateClip(0, 0, { asset: { options: { resolution: "2K" } } } as never);
+			await e.updateClip(0, 0, { start: 1 } as never); // no config field touched
+			expect(configs(spy).map(c => c.options)).toEqual([{ resolution: "1K" }, { resolution: "2K" }]);
+		});
+
+		it("emits nothing for a clip without a prompt", async () => {
+			const { e, spy } = await promptEdit({ asset: { type: "image", src: "https://cdn/x.png" } });
+			e.selectClip(0, 0);
+			expect(configs(spy)).toHaveLength(0);
+		});
+
+		it("emits nothing after the selection is cleared", async () => {
+			const { e, spy } = await promptEdit({ asset: { type: "image", prompt: "a cat" } });
+			e.selectClip(0, 0);
+			e.clearSelection();
+			await e.updateClip(0, 0, { asset: { prompt: "a dog" } } as never);
+			expect(configs(spy)).toHaveLength(1);
+		});
+
+		it("announces the same configuration again when the clip is re-selected", async () => {
+			const { e, spy } = await promptEdit({ asset: { type: "image", prompt: "a cat" } });
+			e.selectClip(0, 0);
+			e.clearSelection();
+			e.selectClip(0, 0);
+			expect(configs(spy).map(c => c.prompt)).toEqual(["a cat", "a cat"]);
+		});
+
+		it("re-emits when a live merge field value edit changes the prompt", async () => {
+			const e = new ShotstackEdit({
+				timeline: { tracks: [{ clips: [{ asset: { type: "image", prompt: "a {{ THING }}" }, start: 0, length: 4 }] }] },
+				merge: [{ find: "THING", replace: "cat" }],
+				output: { size: { width: 1920, height: 1080 }, format: "mp4" }
+			} as never);
+			await e.load();
+			const spy = jest.spyOn(e.getInternalEvents(), "emit");
+			e.selectClip(0, 0);
+			e.updateMergeFieldValueLive("THING", "dog");
+			expect(configs(spy).map(c => c.prompt)).toEqual(["a cat", "a dog"]);
 		});
 	});
 });

--- a/tests/generate-toolbar.test.ts
+++ b/tests/generate-toolbar.test.ts
@@ -36,6 +36,7 @@ function createMockEdit(asset: Record<string, unknown> = { type: "image", prompt
 		getDocument: jest.fn(),
 		hasAssetGenerator: jest.fn().mockReturnValue(true),
 		getClipGenerationState: jest.fn(),
+		getGenerationStatus: jest.fn(),
 		generateClipAsset: jest.fn().mockResolvedValue(undefined),
 		resolveMergeFields: jest.fn((value: string) => value),
 		updateClip: jest.fn(),
@@ -497,5 +498,95 @@ describe("GenerateToolbar", () => {
 		});
 
 		toolbar.dispose();
+	});
+
+	describe("host status", () => {
+		it("shows the host's text in the note slot with its tone", () => {
+			const edit = createMockEdit();
+			edit.getGenerationStatus.mockReturnValue({ text: "neutral line", tone: "neutral" });
+			const { toolbar, container } = mountToolbar(edit);
+			const note = container.querySelector<HTMLElement>("[data-generate-note]");
+			expect(note?.hidden).toBe(false);
+			expect(note?.textContent).toBe("neutral line");
+			expect(note?.dataset["tone"]).toBe("neutral");
+			expect(container.querySelector<HTMLButtonElement>("[data-action='generate']")?.disabled).toBe(false);
+			toolbar.dispose();
+		});
+
+		it("disables Generate only for an error tone", () => {
+			const edit = createMockEdit();
+			edit.getGenerationStatus.mockReturnValue({ text: "blocked", tone: "error" });
+			const { toolbar, container } = mountToolbar(edit);
+			expect(container.querySelector<HTMLButtonElement>("[data-action='generate']")?.disabled).toBe(true);
+			expect(container.querySelector<HTMLElement>("[data-generate-note]")?.dataset["tone"]).toBe("error");
+
+			edit.getGenerationStatus.mockReturnValue({ text: "caution", tone: "warning" });
+			toolbar.show(0, 0);
+			expect(container.querySelector<HTMLButtonElement>("[data-action='generate']")?.disabled).toBe(false);
+			toolbar.dispose();
+		});
+
+		it("hides the note again when the status is cleared", () => {
+			const edit = createMockEdit();
+			edit.getGenerationStatus.mockReturnValue({ text: "x" });
+			const { toolbar, container } = mountToolbar(edit);
+			const note = container.querySelector<HTMLElement>("[data-generate-note]");
+			expect(note?.dataset["tone"]).toBe("neutral");
+			edit.getGenerationStatus.mockReturnValue(undefined);
+			toolbar.show(0, 0);
+			expect(note?.hidden).toBe(true);
+			expect(note?.dataset["tone"]).toBeUndefined();
+			toolbar.dispose();
+		});
+
+		it("still shows the no-generator note when no generator is registered", () => {
+			const edit = createMockEdit();
+			edit.hasAssetGenerator.mockReturnValue(false);
+			edit.getGenerationStatus.mockReturnValue({ text: "ignored" });
+			const { toolbar, container } = mountToolbar(edit);
+			expect(container.querySelector("[data-generate-note]")?.textContent).toBe("Generates on render");
+			toolbar.dispose();
+		});
+
+		it("carries the no-generator tooltip only when no generator is registered", () => {
+			const edit = createMockEdit();
+			edit.hasAssetGenerator.mockReturnValue(false);
+			const { toolbar, container } = mountToolbar(edit);
+			expect(container.querySelector("[data-generate-note]")?.getAttribute("title")).toBe(
+				"Rendering generates this from the prompt. Register an asset generator to preview it here."
+			);
+			toolbar.dispose();
+		});
+
+		it("drops the no-generator tooltip once a generator reports a status", () => {
+			const edit = createMockEdit();
+			edit.getGenerationStatus.mockReturnValue({ text: "now" });
+			const { toolbar, container } = mountToolbar(edit);
+			expect(container.querySelector("[data-generate-note]")?.hasAttribute("title")).toBe(false);
+			toolbar.dispose();
+		});
+
+		it("re-syncs when the status for the selected clip changes", () => {
+			const edit = createMockEdit();
+			const { toolbar, container } = mountToolbar(edit);
+			const handler = edit.getInternalEvents().on.mock.calls.find(([name]) => name === InternalEvent.GenerationStatusChanged)?.[1];
+			expect(handler).toBeDefined();
+			edit.getGenerationStatus.mockReturnValue({ text: "now" });
+			handler({ clipId: "clip-1" });
+			expect(container.querySelector("[data-generate-note]")?.textContent).toBe("now");
+			toolbar.dispose();
+		});
+
+		it("ignores a status change for a clip other than the selected one", () => {
+			const edit = createMockEdit();
+			edit.getGenerationStatus.mockReturnValue({ text: "original" });
+			const { toolbar, container } = mountToolbar(edit);
+			const handler = edit.getInternalEvents().on.mock.calls.find(([name]) => name === InternalEvent.GenerationStatusChanged)?.[1];
+			expect(handler).toBeDefined();
+			edit.getGenerationStatus.mockReturnValue({ text: "unrelated clip's line" });
+			handler({ clipId: "other-clip" });
+			expect(container.querySelector("[data-generate-note]")?.textContent).toBe("original");
+			toolbar.dispose();
+		});
 	});
 });


### PR DESCRIPTION
**Stacked PR [2/2].** The mechanical extraction is already split out into #170 (`refactor: lift generation type and prompt helpers into shared utils`), which is this PR's base branch. This PR contains no refactoring: `git diff <base>...HEAD` touches nine files, `src/core/shared/ai-asset-utils.ts` is not among them, and the refactor commit is not in this PR's commit range. Merge #170 first, then retarget this to `main`.

Studio renders a clip's model and options but the host has no way to say anything about them. This adds one event out and one method in.

`Edit` emits `generation:configChanged` when the selected prompt-bearing clip's model, options, length or prompt changes, carrying `{ clipId, type, model?, options, length, prompt }`. The host replies with `edit.setGenerationStatus(clipId, { text, tone })`, rendered beside Generate.

Non-obvious:

- `length` is a required key typed `number | undefined`. It is `undefined` only for `auto`, where the duration comes from media that does not exist yet; the resolver's placeholder would otherwise be reported as fact.
- Only `tone: "error"` disables Generate. A stale host value should not block work the backend would accept.
- A status for a clip that is not selected is stored but not shown, so a late reply cannot paint the wrong clip.
- The note slot already carried "Generates on render"; with no generator registered that copy still wins over any host status.
- `TimelineUpdated` is a trigger so a live merge-field edit re-announces the resolved prompt.

Verify: `npm run verify:ci`

Risk: 393 lines, roughly half tests. Inert until a host opts in — no behaviour changes without a registered handler and a status call.
