### PR TITLE
fix(deps): align Zod schemas with 1.18.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
 		"vite-plugin-dts": "^4.5.4"
 	},
 	"dependencies": {
-		"@shotstack/schemas": "1.18.0",
+		"@shotstack/schemas": "1.18.3",
 		"@shotstack/shotstack-canvas": "^2.10.2",
 		"howler": "^2.2.4",
 		"mediabunny": "^1.11.2",


### PR DESCRIPTION
Update the pinned `@shotstack/schemas` dependency to `1.18.3` so the SDK uses its Zod validators and generated types, including the current generation-pricing shape and `generating` render status. The existing build bundles the validators; no generated source changes are needed.

Verify: `npm run verify:ci` on Node 22 passed: lint, type checks, 81 suites / 2,060 tests, both builds and package contract checks.

Risk: Generated pricing types replace `unit`/`minUnits` with `quantity` and change `tieredBy` from an array to an object.
